### PR TITLE
BUG: Fix incorrect pixel RGB standard deviation

### DIFF
--- a/bioscan_dataset/bioscan1m.py
+++ b/bioscan_dataset/bioscan1m.py
@@ -17,7 +17,7 @@ import torch
 from torchvision.datasets.vision import VisionDataset
 
 RGB_MEAN = torch.tensor([0.72510918, 0.72891550, 0.72956181])
-RGB_STDEV = torch.tensor([0.66364000, 0.66088159, 0.66035860])
+RGB_STDEV = torch.tensor([0.12654378, 0.14301962, 0.16103319])
 
 COLUMN_DTYPES = {
     "sampleid": str,

--- a/bioscan_dataset/bioscan5m.py
+++ b/bioscan_dataset/bioscan5m.py
@@ -18,7 +18,8 @@ from torchvision.datasets.utils import check_integrity, download_and_extract_arc
 from torchvision.datasets.vision import VisionDataset
 
 RGB_MEAN = torch.tensor([0.76281859, 0.76503749, 0.76373138])
-RGB_STDEV = torch.tensor([0.67122520, 0.66740192, 0.66488950])
+RGB_STDEV = torch.tensor([0.14205404, 0.15642502, 0.17309470])
+
 
 COLUMN_DTYPES = {
     "processid": str,


### PR DESCRIPTION
I had accidentally put the division by 255 in the wrong place when calculating the standard deviation of pixel intensities across the dataset.

Previous method (incorrect):

```python
import numpy as np
from tqdm.autonotebook import tqdm
from bioscan_dataset import BIOSCAN5M

ds = BIOSCAN5M("~/Datasets/bioscan-5m", modality="image", split="all")

rgb_total = np.zeros((3,), dtype=np.uint64)
rgb_sq_total = np.zeros((3,), dtype=np.uint64)
n_pixel = 0
for x, y in tqdm(ds):
    n_pixel += x.width * x.height
    rgb_total += np.sum(x, axis=0).sum(axis=0)
    rgb_sq_total += np.sum(np.asarray(x) ** 2, axis=0).sum(axis=0)

rgb_mean = rgb_total / n_pixel / 255
rgb_std = np.sqrt((rgb_sq_total - rgb_total * rgb_total / n_pixel) / (n_pixel - 1) / 255)
```

Since we already have an accurate estimate of the mean pixel intensity, I reused this to do the two-step implementation of the std estimation.

```python
import numpy as np
from tqdm.autonotebook import tqdm
from bioscan_dataset import BIOSCAN5M

ds = BIOSCAN5M("~/Datasets/bioscan-5m", modality="image", split="all")

RGB_MEAN = np.load("rgb_mean__bs5m.npy")   # Load previous calculation

scaled_sq_total = np.zeros((3,), dtype=np.float64)
n_pixel = 0
for x, y in tqdm(ds):
    n_pixel += x.width * x.height
    x = np.asarray(x) / 255
    x = x - RGB_MEAN
    scaled_sq_total += np.sum(np.square(x), axis=0).sum(axis=0)

rgb_std = np.sqrt(scaled_sq_total / (n_pixel - 1))
```