### PR TITLE
DOC: Add Google Analytics to READTHEDOCS documentation builds

### DIFF
--- a/docs/source/conf.py
+++ b/docs/source/conf.py
@@ -138,6 +138,10 @@ if sys.version_info >= (3, 6):
     # but only available on Python 3.6 and above.
     extensions.append("sphinx_search.extension")
 
+# Some extensions should only be run if we are on Read the Docs
+if os.environ.get("READTHEDOCS") == "True":
+    extensions.append("sphinxcontrib.googleanalytics")
+
 # Napoleon settings
 napoleon_google_docstring = True
 napoleon_numpy_docstring = True
@@ -303,3 +307,7 @@ intersphinx_mapping = {
 
 # If true, `todo` and `todoList` produce output, else they produce nothing.
 todo_include_todos = True
+
+# -- Options for Google Analytics extension ----------------------------------
+
+googleanalytics_id = "G-9F4YTY8WM2"

--- a/requirements-docs.txt
+++ b/requirements-docs.txt
@@ -5,4 +5,5 @@ readthedocs-sphinx-search; python_version>='3.6'
 sphinx>=6.0.0
 sphinx-autobuild
 sphinx_rtd_theme
+sphinxcontrib-googleanalytics>=0.4
 watchdog<1.0.0; python_version<'3.6'


### PR DESCRIPTION
This will help to track usage of the online documentation.