### PR TITLE
Add "target_format" to the input of BIOSCAN1M/BIOSCAN5M dataset

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -180,7 +180,9 @@ or a list of labels, e.g.
        root="~/Datasets/bioscan/bioscan-5m/", target_type=["genus", "species", "dna_bin"]
    )
 
-The value of the target yielded for a data sample is an integer corresponding to the index of its label.
+The format of the target label can be specified by setting the ``target_format`` argument to either ``"index"`` or ``"text"``.
+The default setting is ``"index"``, which returns the integer index corresponding to the label.
+If ``"text"`` is selected, the output will be the actual string representation of the label.
 
 
 Data transforms

--- a/README.rst
+++ b/README.rst
@@ -180,9 +180,26 @@ or a list of labels, e.g.
        root="~/Datasets/bioscan/bioscan-5m/", target_type=["genus", "species", "dna_bin"]
    )
 
-The format of the target label can be specified by setting the ``target_format`` argument to either ``"index"`` or ``"text"``.
-The default setting is ``"index"``, which returns the integer index corresponding to the label.
-If ``"text"`` is selected, the output will be the actual string representation of the label.
+By default, the target values will be provided as integer indices that map to the labels for that taxonomic rank (with value ``-1`` used for missing labels), appropriate for training a classification model with cross-entropy.
+This format can be controlled with the ``target_format`` argument, which takes values of either ``"index"`` or ``"text"``.
+If this is set to ``target_format="text"``, the output will instead be the raw label string:
+
+.. code-block:: python
+
+   # Default target format is "index"
+   dataset = BIOSCAN5M(
+       root="~/Datasets/bioscan/bioscan-5m/", target_type="species", target_format="index"
+   )
+   assert dataset[0][-1] is 240
+
+   # Using target format "text"
+   dataset = BIOSCAN5M(
+       root="~/Datasets/bioscan/bioscan-5m/", target_type="species", target_format="text"
+   )
+   assert dataset[0][-1] is "Gnamptogenys sulcata"
+
+The default setting is ``target_format="index"``.
+Note that if multiple targets types are given, each label will be returned in the same format.
 
 
 Data transforms

--- a/bioscan_dataset/bioscan1m.py
+++ b/bioscan_dataset/bioscan1m.py
@@ -355,6 +355,8 @@ class BIOSCAN1M(VisionDataset):
                 target.append(sample[f"{t}_index"])
             elif self.target_format == "text":
                 target.append(sample[t])
+            else:
+                raise ValueError(f"Unknown target_format: {self.target_format}")
 
         if target:
             target = tuple(target) if len(target) > 1 else target[0]

--- a/bioscan_dataset/bioscan1m.py
+++ b/bioscan_dataset/bioscan1m.py
@@ -261,8 +261,15 @@ class BIOSCAN1M(VisionDataset):
         Where ``"uri"`` corresponds to the BIN cluster label.
 
     target_format : str, default="index"
-        Format of the target value. One of:
+        Format in which the targets will be returned. One of:
         ``"index"``, ``"text"``.
+        If this is set to ``"index"`` (default), target(s) will each be returned as
+        integer indices, each of which corresponds to a value for that taxonomic rank in
+        a look-up-table.
+        Missing values will be filled with ``-1``.
+        This format is appropriate for use in classification tasks.
+        If this is set to ``"text"``, the target(s) will each be returned as a string,
+        appropriate for processing with language models.
 
     transform : Callable, default=None
         Image transformation pipeline.

--- a/bioscan_dataset/bioscan1m.py
+++ b/bioscan_dataset/bioscan1m.py
@@ -354,7 +354,7 @@ class BIOSCAN1M(VisionDataset):
             if self.target_format == "index":
                 target.append(sample[f"{t}_index"])
             elif self.target_format == "text":
-                target.append(sample[f"{t}"])
+                target.append(sample[t])
 
         if target:
             target = tuple(target) if len(target) > 1 else target[0]

--- a/bioscan_dataset/bioscan1m.py
+++ b/bioscan_dataset/bioscan1m.py
@@ -260,6 +260,10 @@ class BIOSCAN1M(VisionDataset):
 
         Where ``"uri"`` corresponds to the BIN cluster label.
 
+    target_format : str, default="index"
+        Format of the target value. One of:
+        ``"index"``, ``"text"``.
+
     transform : Callable, default=None
         Image transformation pipeline.
 
@@ -279,6 +283,7 @@ class BIOSCAN1M(VisionDataset):
         reduce_repeated_barcodes=False,
         max_nucleotides=660,
         target_type="family",
+        target_format="index",
         transform=None,
         dna_transform=None,
         target_transform=None,
@@ -297,6 +302,7 @@ class BIOSCAN1M(VisionDataset):
 
         self.partitioning_version = partitioning_version
         self.split = split
+        self.target_format = target_format
         self.reduce_repeated_barcodes = reduce_repeated_barcodes
         self.max_nucleotides = max_nucleotides
         self.dna_transform = dna_transform
@@ -314,6 +320,9 @@ class BIOSCAN1M(VisionDataset):
 
         if not self.target_type and self.target_transform is not None:
             raise RuntimeError("target_transform is specified but target_type is empty")
+
+        if self.target_format not in ["index", "text"]:
+            raise ValueError(f"Unknown target_format: {self.target_format}")
 
         if not self._check_exists():
             raise EnvironmentError(f"{type(self).__name__} dataset not found in {self.root}.")
@@ -342,7 +351,10 @@ class BIOSCAN1M(VisionDataset):
 
         target = []
         for t in self.target_type:
-            target.append(sample[f"{t}_index"])
+            if self.target_format == "index":
+                target.append(sample[f"{t}_index"])
+            elif self.target_format == "text":
+                target.append(sample[f"{t}"])
 
         if target:
             target = tuple(target) if len(target) > 1 else target[0]

--- a/bioscan_dataset/bioscan5m.py
+++ b/bioscan_dataset/bioscan5m.py
@@ -250,8 +250,15 @@ class BIOSCAN5M(VisionDataset):
         - ``"dna_bin"``
 
     target_format : str, default="index"
-        Format of the target value. One of:
+        Format in which the targets will be returned. One of:
         ``"index"``, ``"text"``.
+        If this is set to ``"index"`` (default), target(s) will each be returned as
+        integer indices, each of which corresponds to a value for that taxonomic rank in
+        a look-up-table.
+        Missing values will be filled with ``-1``.
+        This format is appropriate for use in classification tasks.
+        If this is set to ``"text"``, the target(s) will each be returned as a string,
+        appropriate for processing with language models.
 
     transform : Callable, default=None
         Image transformation pipeline.

--- a/bioscan_dataset/bioscan5m.py
+++ b/bioscan_dataset/bioscan5m.py
@@ -249,6 +249,10 @@ class BIOSCAN5M(VisionDataset):
         - ``"species"``
         - ``"dna_bin"``
 
+    target_format : str, default="index"
+        Format of the target value. One of:
+        ``"index"``, ``"text"``.
+
     transform : Callable, default=None
         Image transformation pipeline.
 
@@ -346,6 +350,7 @@ class BIOSCAN5M(VisionDataset):
         reduce_repeated_barcodes=False,
         max_nucleotides=660,
         target_type="species",
+        target_format="index",
         transform=None,
         dna_transform=None,
         target_transform=None,
@@ -361,6 +366,7 @@ class BIOSCAN5M(VisionDataset):
         self.metadata_path = os.path.join(self.root, self.base_folder, self.meta["filename"])
 
         self.split = split
+        self.target_format = target_format
         self.reduce_repeated_barcodes = reduce_repeated_barcodes
         self.max_nucleotides = max_nucleotides
         self.dna_transform = dna_transform
@@ -378,6 +384,9 @@ class BIOSCAN5M(VisionDataset):
 
         if not self.target_type and self.target_transform is not None:
             raise RuntimeError("target_transform is specified but target_type is empty")
+
+        if self.target_format not in ["index", "text"]:
+            raise ValueError(f"Unknown target_format: {self.target_format}")
 
         if download:
             self.download()
@@ -409,7 +418,10 @@ class BIOSCAN5M(VisionDataset):
 
         target = []
         for t in self.target_type:
-            target.append(sample[f"{t}_index"])
+            if self.target_format == "index":
+                target.append(sample[f"{t}_index"])
+            elif self.target_format == "text":
+                target.append(sample[f"{t}"])
 
         if target:
             target = tuple(target) if len(target) > 1 else target[0]

--- a/bioscan_dataset/bioscan5m.py
+++ b/bioscan_dataset/bioscan5m.py
@@ -422,6 +422,8 @@ class BIOSCAN5M(VisionDataset):
                 target.append(sample[f"{t}_index"])
             elif self.target_format == "text":
                 target.append(sample[t])
+            else:
+                raise ValueError(f"Unknown target_format: {self.target_format}")
 
         if target:
             target = tuple(target) if len(target) > 1 else target[0]

--- a/bioscan_dataset/bioscan5m.py
+++ b/bioscan_dataset/bioscan5m.py
@@ -421,7 +421,7 @@ class BIOSCAN5M(VisionDataset):
             if self.target_format == "index":
                 target.append(sample[f"{t}_index"])
             elif self.target_format == "text":
-                target.append(sample[f"{t}"])
+                target.append(sample[t])
 
         if target:
             target = tuple(target) if len(target) > 1 else target[0]


### PR DESCRIPTION
I've added an input parameter `target_format` (str) with options ["index"|"text"] to specify the output format of the target labels. 
By default, this parameter is set to "index," which maintains the original functionality. 
If set to "text," the dataset will output the taxonomy labels in text of the target selection.