### PR TITLE
DOC: Move badges onto one line of README

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -1,18 +1,7 @@
+|PyPI badge| |License| |Documentation| |black| |pre-commit| |DOI badge|
 
 BIOSCAN Datasets for PyTorch
 ============================
-
-+------------------+----------------------------------------------------------------------+
-| Latest Release   | |PyPI badge|                                                         |
-+------------------+----------------------------------------------------------------------+
-| License          | |License|                                                            |
-+------------------+----------------------------------------------------------------------+
-| Documentation    | |Documentation|                                                      |
-+------------------+----------------------------------------------------------------------+
-| Code style       | |black| |pre-commit|                                                 |
-+------------------+----------------------------------------------------------------------+
-| Citation         | |DOI badge|                                                          |
-+------------------+----------------------------------------------------------------------+
 
 In this package, we provide PyTorch/torchvision style dataset classes to load the `BIOSCAN-1M <BIOSCAN-1M paper_>`_ and `BIOSCAN-5M <BIOSCAN-5M paper_>`_ datasets.
 

--- a/README.rst
+++ b/README.rst
@@ -1,4 +1,13 @@
-|PyPI badge| |License| |Documentation| |black| |pre-commit| |DOI badge|
+.. raw:: html
+
+   <p style="margin: 0;">
+     <a href="https://pypi.org/project/bioscan-dataset/"><img alt="Latest PyPI release" src="https://img.shields.io/pypi/v/bioscan-dataset.svg" style="max-width: 100%;"></a>
+     <a href="https://raw.githubusercontent.com/bioscan-ml/dataset/master/LICENSE"><img alt="MIT License" src="https://img.shields.io/pypi/l/bioscan-dataset" style="max-width: 100%;"></a>
+     <a href="https://bioscan-dataset.readthedocs.io"><img alt="Documentation" src="https://img.shields.io/badge/docs-readthedocs-blue" style="max-width: 100%;"></a>
+     <a href="https://github.com/psf/black"><img alt="black" src="https://img.shields.io/badge/code%20style-black-000000.svg" style="max-width: 100%;"></a>
+     <a href="https://github.com/pre-commit/pre-commit"><img alt="pre-commit enabled" src="https://img.shields.io/badge/pre--commit-enabled-brightgreen?logo=pre-commit&amp;logoColor=white" style="max-width: 100%;"></a>
+     <a href="https://www.doi.org/10.48550/arxiv.2406.12723"><img alt="DOI" src="https://img.shields.io/badge/DOI-10.48550/arxiv.2406.12723-blue.svg" style="max-width: 100%;"></a>
+   </p>
 
 BIOSCAN Datasets for PyTorch
 ============================
@@ -312,22 +321,3 @@ If you make use of the BIOSCAN-1M or BIOSCAN-5M datasets in your research, pleas
 .. _pip: https://pip.pypa.io/
 .. _PyPI: https://pypi.org/project/bioscan-dataset/
 .. _readthedocs: https://bioscan-dataset.readthedocs.io
-
-.. |PyPI badge| image:: https://img.shields.io/pypi/v/bioscan-dataset.svg
-   :target: PyPI_
-   :alt: Latest PyPI release
-.. |Documentation| image:: https://img.shields.io/badge/docs-readthedocs-blue
-   :target: readthedocs_
-   :alt: Documentation
-.. |DOI badge| image:: https://img.shields.io/badge/DOI-10.48550/arxiv.2406.12723-blue.svg
-   :target: https://www.doi.org/10.48550/arxiv.2406.12723
-   :alt: DOI
-.. |License| image:: https://img.shields.io/pypi/l/bioscan-dataset
-   :target: https://raw.githubusercontent.com/bioscan-ml/dataset/master/LICENSE
-   :alt: MIT License
-.. |pre-commit| image:: https://img.shields.io/badge/pre--commit-enabled-brightgreen?logo=pre-commit&logoColor=white
-   :target: https://github.com/pre-commit/pre-commit
-   :alt: pre-commit enabled
-.. |black| image:: https://img.shields.io/badge/code%20style-black-000000.svg
-   :target: https://github.com/psf/black
-   :alt: black

--- a/docs/source/index.rst
+++ b/docs/source/index.rst
@@ -2,7 +2,7 @@ BIOSCAN Dataset Package
 =======================
 
 .. include:: readme.rst
-    :start-line: 5
+    :start-line: 14
 
 .. toctree::
     :maxdepth: 2

--- a/docs/source/index.rst
+++ b/docs/source/index.rst
@@ -2,7 +2,7 @@ BIOSCAN Dataset Package
 =======================
 
 .. include:: readme.rst
-    :start-line: 15
+    :start-line: 5
 
 .. toctree::
     :maxdepth: 2


### PR DESCRIPTION
We don't have that many and don't need to focus on them so much, so let's change from the table to a single line of badges.

GitHub is messing up the rendering by adding line-wraps in the middle of some of the anchors, which creates spaces that are part of the hyperlink. To prevent this, we are using raw HTML for the badges instead of rST.