### PR TITLE
API+MNT: index2label

### DIFF
--- a/bioscan_dataset/bioscan1m.py
+++ b/bioscan_dataset/bioscan1m.py
@@ -371,7 +371,7 @@ class BIOSCAN1M(VisionDataset):
 
     def index2label(
         self,
-        index: Union[int, Iterable[int]],
+        index: Union[int, npt.ArrayLike],
         column: Optional[str] = None,
     ) -> Union[str, npt.NDArray[np.str_]]:
         r"""
@@ -381,7 +381,7 @@ class BIOSCAN1M(VisionDataset):
 
         Parameters
         ----------
-        index : int or Iterable[int]
+        index : int or array_like[int]
             The integer index or indices to map to labels.
         column : str, default=same as ``self.target_type``
             The dataset column name to map.

--- a/bioscan_dataset/bioscan1m.py
+++ b/bioscan_dataset/bioscan1m.py
@@ -11,7 +11,7 @@ BIOSCAN-1M PyTorch dataset.
 import os
 import warnings
 from enum import Enum
-from typing import Any, Iterable, Tuple, Union
+from typing import Any, Iterable, Optional, Tuple, Union
 
 import numpy as np
 import numpy.typing as npt
@@ -369,7 +369,11 @@ class BIOSCAN1M(VisionDataset):
 
         self._load_metadata()
 
-    def index2label(self, column: str, index: Union[int, Iterable[int]]) -> Union[str, npt.NDArray[np.str_]]:
+    def index2label(
+        self,
+        index: Union[int, Iterable[int]],
+        column: Optional[str] = None,
+    ) -> Union[str, npt.NDArray[np.str_]]:
         r"""
         Convert target's integer index to text label.
 
@@ -377,10 +381,13 @@ class BIOSCAN1M(VisionDataset):
 
         Parameters
         ----------
-        column : str
-            The dataset column name to map. This is the same as the ``target_type``.
         index : int or Iterable[int]
             The integer index or indices to map to labels.
+        column : str, default=same as ``self.target_type``
+            The dataset column name to map.
+            This should be one of the possible values for ``target_type``.
+            By default, the column name is the ``target_type`` used for the class,
+            provided it is a single value.
 
         Returns
         -------
@@ -390,6 +397,12 @@ class BIOSCAN1M(VisionDataset):
             Entries containing missing values, indicated by negative indices, are mapped
             to an empty string.
         """
+        if column is not None:
+            pass
+        elif len(self.target_type) == 1:
+            column = self.target_type[0]
+        else:
+            raise ValueError("column must be specified if there isn't a single target_type")
         if not hasattr(index, "__len__"):
             # Single index
             if index < 0:
@@ -401,7 +414,11 @@ class BIOSCAN1M(VisionDataset):
         out[index < 0] = ""
         return out
 
-    def label2index(self, column: str, label: Union[str, Iterable[str]]) -> Union[int, npt.NDArray[np.int_]]:
+    def label2index(
+        self,
+        label: Union[str, Iterable[str]],
+        column: Optional[str] = None,
+    ) -> Union[int, npt.NDArray[np.int_]]:
         r"""
         Convert target's text label to integer index.
 
@@ -409,10 +426,13 @@ class BIOSCAN1M(VisionDataset):
 
         Parameters
         ----------
-        column : str
-            The dataset column name to map. This is the same as the ``target_type``.
         label : str or Iterable[str]
             The text label or labels to map to integer indices.
+        column : str, default=same as ``self.target_type``
+            The dataset column name to map.
+            This should be one of the possible values for ``target_type``.
+            By default, the column name is the ``target_type`` used for the class,
+            provided it is a single value.
 
         Returns
         -------
@@ -422,6 +442,12 @@ class BIOSCAN1M(VisionDataset):
             Entries containing missing values, indicated by empty strings, are mapped
             to ``-1``.
         """
+        if column is not None:
+            pass
+        elif len(self.target_type) == 1:
+            column = self.target_type[0]
+        else:
+            raise ValueError("column must be specified if there isn't a single target_type")
         if isinstance(label, str):
             # Single index
             if label == "":

--- a/bioscan_dataset/bioscan1m.py
+++ b/bioscan_dataset/bioscan1m.py
@@ -452,9 +452,15 @@ class BIOSCAN1M(VisionDataset):
             # Single index
             if label == "":
                 return -1
-            return self.metadata[column].cat.categories.get_loc(label)
+            try:
+                return self.metadata[column].cat.categories.get_loc(label)
+            except KeyError:
+                raise KeyError(f"Label '{label}' not found in metadata column '{column}'") from None
         labels = label
-        out = [-1 if lab == "" else self.metadata[column].cat.categories.get_loc(lab) for lab in labels]
+        try:
+            out = [-1 if lab == "" else self.metadata[column].cat.categories.get_loc(lab) for lab in labels]
+        except KeyError:
+            raise KeyError(f"Label '{label}' not found in metadata column '{column}'") from None
         out = np.asarray(out)
         return out
 

--- a/bioscan_dataset/bioscan5m.py
+++ b/bioscan_dataset/bioscan5m.py
@@ -513,9 +513,15 @@ class BIOSCAN5M(VisionDataset):
             # Single index
             if label == "":
                 return -1
-            return self.metadata[column].cat.categories.get_loc(label)
+            try:
+                return self.metadata[column].cat.categories.get_loc(label)
+            except KeyError:
+                raise KeyError(f"Label '{label}' not found in metadata column '{column}'") from None
         labels = label
-        out = [-1 if lab == "" else self.metadata[column].cat.categories.get_loc(lab) for lab in labels]
+        try:
+            out = [-1 if lab == "" else self.metadata[column].cat.categories.get_loc(lab) for lab in labels]
+        except KeyError:
+            raise KeyError(f"Label '{label}' not found in metadata column '{column}'") from None
         out = np.asarray(out)
         return out
 

--- a/bioscan_dataset/bioscan5m.py
+++ b/bioscan_dataset/bioscan5m.py
@@ -418,7 +418,7 @@ class BIOSCAN5M(VisionDataset):
 
     def index2label(
         self,
-        index: Union[int, Iterable[int]],
+        index: Union[int, npt.ArrayLike],
         column: Optional[str] = None,
     ) -> Union[str, npt.NDArray[np.str_]]:
         r"""
@@ -428,7 +428,7 @@ class BIOSCAN5M(VisionDataset):
 
         Parameters
         ----------
-        index : int or Iterable[int]
+        index : int or array_like[int]
             The integer index or indices to map to labels.
         column : str, default=same as ``self.target_type``
             The dataset column name to map.

--- a/bioscan_dataset/bioscan5m.py
+++ b/bioscan_dataset/bioscan5m.py
@@ -10,7 +10,7 @@ BIOSCAN-5M PyTorch Dataset.
 
 import os
 from enum import Enum
-from typing import Any, Iterable, Tuple, Union
+from typing import Any, Iterable, Optional, Tuple, Union
 
 import numpy as np
 import numpy.typing as npt
@@ -416,7 +416,11 @@ class BIOSCAN5M(VisionDataset):
 
         self._load_metadata()
 
-    def index2label(self, column: str, index: Union[int, Iterable[int]]) -> Union[str, npt.NDArray[np.str_]]:
+    def index2label(
+        self,
+        index: Union[int, Iterable[int]],
+        column: Optional[str] = None,
+    ) -> Union[str, npt.NDArray[np.str_]]:
         r"""
         Convert target's integer index to text label.
 
@@ -424,10 +428,13 @@ class BIOSCAN5M(VisionDataset):
 
         Parameters
         ----------
-        column : str
-            The dataset column name to map. This is the same as the ``target_type``.
         index : int or Iterable[int]
             The integer index or indices to map to labels.
+        column : str, default=same as ``self.target_type``
+            The dataset column name to map.
+            This should be one of the possible values for ``target_type``.
+            By default, the column name is the ``target_type`` used for the class,
+            provided it is a single value.
 
         Returns
         -------
@@ -439,11 +446,17 @@ class BIOSCAN5M(VisionDataset):
 
         Examples
         --------
-        >>> dataset.index2label("order", [4])
+        >>> dataset.index2label([4], "order")
         'Diptera'
-        >>> dataset.index2label("order", [4, 9, -1, 4])
+        >>> dataset.index2label([4, 9, -1, 4], "order")
         array(['Diptera', 'Lepidoptera', '', 'Diptera'], dtype=object)
         """
+        if column is not None:
+            pass
+        elif len(self.target_type) == 1:
+            column = self.target_type[0]
+        else:
+            raise ValueError("column must be specified if there isn't a single target_type")
         if not hasattr(index, "__len__"):
             # Single index
             if index < 0:
@@ -455,7 +468,11 @@ class BIOSCAN5M(VisionDataset):
         out[index < 0] = ""
         return out
 
-    def label2index(self, column: str, label: Union[str, Iterable[str]]) -> Union[int, npt.NDArray[np.int_]]:
+    def label2index(
+        self,
+        label: Union[str, Iterable[str]],
+        column: Optional[str] = None,
+    ) -> Union[int, npt.NDArray[np.int_]]:
         r"""
         Convert target's text label to integer index.
 
@@ -463,10 +480,13 @@ class BIOSCAN5M(VisionDataset):
 
         Parameters
         ----------
-        column : str
-            The dataset column name to map. This is the same as the ``target_type``.
         label : str or Iterable[str]
             The text label or labels to map to integer indices.
+        column : str, default=same as ``self.target_type``
+            The dataset column name to map.
+            This should be one of the possible values for ``target_type``.
+            By default, the column name is the ``target_type`` used for the class,
+            provided it is a single value.
 
         Returns
         -------
@@ -478,11 +498,17 @@ class BIOSCAN5M(VisionDataset):
 
         Examples
         --------
-        >>> dataset.label2index("order", "Diptera")
+        >>> dataset.label2index("Diptera", "order")
         4
-        >>> dataset.label2index("order", ["Diptera", "Lepidoptera", "", "Diptera"])
+        >>> dataset.label2index(["Diptera", "Lepidoptera", "", "Diptera"], "order")
         array([4, 9, -1, 4])
         """
+        if column is not None:
+            pass
+        elif len(self.target_type) == 1:
+            column = self.target_type[0]
+        else:
+            raise ValueError("column must be specified if there isn't a single target_type")
         if isinstance(label, str):
             # Single index
             if label == "":


### PR DESCRIPTION
Builds on #12.
- Changes the argument order from `f(column, label)` to `f(label, column)`
- Make column optional, with a default value of `target_type`
- Fix type hinting as the input must be array_like (generic iterables aren't supported)