### PR TITLE
REL: Release version 1.1.0

### DIFF
--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -11,6 +11,59 @@ The format is based on `Keep a Changelog`_, and this project adheres to `Semanti
 Categories for changes are: Added, Changed, Deprecated, Removed, Fixed, Security.
 
 
+Version `1.1.0 <https://github.com/bioscan-ml/dataset/tree/v1.1.0>`__
+---------------------------------------------------------------------
+
+Release date: 2025-03-27.
+`Full commit changelog <https://github.com/bioscan-ml/dataset/compare/v1.0.1...v1.1.0>`__.
+
+This is a minor release adding some new features.
+
+.. _v1.1.0 Added:
+
+Added
+~~~~~
+
+-   Added ``target_format`` argument which controls whether taxonomic labels are returned by ``__getitem__`` as a strings or integers indicating the class index
+    (`#10 <https://github.com/bioscan-ml/dataset/pull/10>`__).
+    Thanks to `@xl-huo <https://github.com/xl-huo>`_ for contributing this.
+
+-   Added ``index2label`` and ``label2index`` properties to the dataset class to map between class indices and taxonomic labels
+    (`#12 <https://github.com/bioscan-ml/dataset/pull/12>`__,
+    `#23 <https://github.com/bioscan-ml/dataset/pull/23>`__).
+
+-   Added support for arbitrary modality names, which are taken from the metadata, without the option to apply a transform to the data
+    (`#13 <https://github.com/bioscan-ml/dataset/pull/13>`__).
+
+-   Added ``image_package`` argument to BIOSCAN1M, to select the image package to use, as was alreaday implemented for BIOSCAN5M
+    (`#15 <https://github.com/bioscan-ml/dataset/pull/15>`__).
+
+-   Added an warning to BIOSCAN1M that is automatically raised if one of the requested target ranks is incompatible with the selected ``partitioning_version``
+    (`#18 <https://github.com/bioscan-ml/dataset/pull/18>`__).
+    Thanks `@kevinkasa <https://github.com/kevinkasa>`__ for highlighting this.
+
+.. _v1.1.0 Documentation:
+
+Documentation
+~~~~~~~~~~~~~
+
+-   Changed color scheme to match `bioscan-browser <https://bioscan-browser.netlify.app/style-guide_>`_
+    (`#4 <https://github.com/bioscan-ml/dataset/pull/4>`__).
+    Thanks to `@annavik <https://github.com/annavik>`_ for contributing to this.
+
+-   Corrected example usage to use a single tuple, not nested
+    (`#5 <https://github.com/bioscan-ml/dataset/pull/5>`__).
+    Thanks to `@xl-huo <https://github.com/xl-huo>`_ for reporting this.
+
+-   General documentation improvements
+    (`#3 <https://github.com/bioscan-ml/dataset/pull/3>`__,
+    `#11 <https://github.com/bioscan-ml/dataset/pull/11>`__,
+    `#14 <https://github.com/bioscan-ml/dataset/pull/14>`__,
+    `#16 <https://github.com/bioscan-ml/dataset/pull/16>`__,
+    `#17 <https://github.com/bioscan-ml/dataset/pull/17>`__,
+    `#22 <https://github.com/bioscan-ml/dataset/pull/22>`__).
+
+
 Version `1.0.1 <https://github.com/bioscan-ml/dataset/tree/v1.0.1>`__
 ---------------------------------------------------------------------
 

--- a/README.rst
+++ b/README.rst
@@ -3,7 +3,7 @@
    <p style="margin: 0;">
      <a href="https://pypi.org/project/bioscan-dataset/"><img alt="Latest PyPI release" src="https://img.shields.io/pypi/v/bioscan-dataset.svg" style="max-width: 100%;"></a>
      <a href="https://raw.githubusercontent.com/bioscan-ml/dataset/master/LICENSE"><img alt="MIT License" src="https://img.shields.io/pypi/l/bioscan-dataset" style="max-width: 100%;"></a>
-     <a href="https://bioscan-dataset.readthedocs.io"><img alt="Documentation" src="https://img.shields.io/badge/docs-readthedocs-blue" style="max-width: 100%;"></a>
+     <a href="https://bioscan-dataset.readthedocs.io/en/v1.1.0/"><img alt="Documentation" src="https://img.shields.io/badge/docs-readthedocs-blue" style="max-width: 100%;"></a>
      <a href="https://github.com/psf/black"><img alt="black" src="https://img.shields.io/badge/code%20style-black-000000.svg" style="max-width: 100%;"></a>
      <a href="https://github.com/pre-commit/pre-commit"><img alt="pre-commit enabled" src="https://img.shields.io/badge/pre--commit-enabled-brightgreen?logo=pre-commit&amp;logoColor=white" style="max-width: 100%;"></a>
      <a href="https://www.doi.org/10.48550/arxiv.2406.12723"><img alt="DOI" src="https://img.shields.io/badge/DOI-10.48550/arxiv.2406.12723-blue.svg" style="max-width: 100%;"></a>
@@ -324,9 +324,9 @@ If you make use of the BIOSCAN-1M or BIOSCAN-5M datasets in your research, pleas
 .. _BIOSCAN Browser: https://bioscan-browser.netlify.app/
 .. _BIOSCAN-1M paper: https://papers.nips.cc/paper_files/paper/2023/hash/87dbbdc3a685a97ad28489a1d57c45c1-Abstract-Datasets_and_Benchmarks.html
 .. _BIOSCAN-5M paper: https://arxiv.org/abs/2406.12723
-.. _BS1M-class: https://bioscan-dataset.readthedocs.io/en/stable/api.html#bioscan_dataset.BIOSCAN1M
-.. _BS5M-class: https://bioscan-dataset.readthedocs.io/en/stable/api.html#bioscan_dataset.BIOSCAN5M
+.. _BS1M-class: https://bioscan-dataset.readthedocs.io/en/v1.1.0/api.html#bioscan_dataset.BIOSCAN1M
+.. _BS5M-class: https://bioscan-dataset.readthedocs.io/en/v1.1.0/api.html#bioscan_dataset.BIOSCAN5M
 .. _our repo: https://github.com/bioscan-ml/dataset
 .. _pip: https://pip.pypa.io/
 .. _PyPI: https://pypi.org/project/bioscan-dataset/
-.. _readthedocs: https://bioscan-dataset.readthedocs.io
+.. _readthedocs: https://bioscan-dataset.readthedocs.io/en/v1.1.0/

--- a/README.rst
+++ b/README.rst
@@ -3,7 +3,7 @@
    <p style="margin: 0;">
      <a href="https://pypi.org/project/bioscan-dataset/"><img alt="Latest PyPI release" src="https://img.shields.io/pypi/v/bioscan-dataset.svg" style="max-width: 100%;"></a>
      <a href="https://raw.githubusercontent.com/bioscan-ml/dataset/master/LICENSE"><img alt="MIT License" src="https://img.shields.io/pypi/l/bioscan-dataset" style="max-width: 100%;"></a>
-     <a href="https://bioscan-dataset.readthedocs.io/en/v1.1.0/"><img alt="Documentation" src="https://img.shields.io/badge/docs-readthedocs-blue" style="max-width: 100%;"></a>
+     <a href="https://bioscan-dataset.readthedocs.io"><img alt="Documentation" src="https://img.shields.io/badge/docs-readthedocs-blue" style="max-width: 100%;"></a>
      <a href="https://github.com/psf/black"><img alt="black" src="https://img.shields.io/badge/code%20style-black-000000.svg" style="max-width: 100%;"></a>
      <a href="https://github.com/pre-commit/pre-commit"><img alt="pre-commit enabled" src="https://img.shields.io/badge/pre--commit-enabled-brightgreen?logo=pre-commit&amp;logoColor=white" style="max-width: 100%;"></a>
      <a href="https://www.doi.org/10.48550/arxiv.2406.12723"><img alt="DOI" src="https://img.shields.io/badge/DOI-10.48550/arxiv.2406.12723-blue.svg" style="max-width: 100%;"></a>
@@ -324,9 +324,9 @@ If you make use of the BIOSCAN-1M or BIOSCAN-5M datasets in your research, pleas
 .. _BIOSCAN Browser: https://bioscan-browser.netlify.app/
 .. _BIOSCAN-1M paper: https://papers.nips.cc/paper_files/paper/2023/hash/87dbbdc3a685a97ad28489a1d57c45c1-Abstract-Datasets_and_Benchmarks.html
 .. _BIOSCAN-5M paper: https://arxiv.org/abs/2406.12723
-.. _BS1M-class: https://bioscan-dataset.readthedocs.io/en/v1.1.0/api.html#bioscan_dataset.BIOSCAN1M
-.. _BS5M-class: https://bioscan-dataset.readthedocs.io/en/v1.1.0/api.html#bioscan_dataset.BIOSCAN5M
+.. _BS1M-class: https://bioscan-dataset.readthedocs.io/en/stable/api.html#bioscan_dataset.BIOSCAN1M
+.. _BS5M-class: https://bioscan-dataset.readthedocs.io/en/stable/api.html#bioscan_dataset.BIOSCAN5M
 .. _our repo: https://github.com/bioscan-ml/dataset
 .. _pip: https://pip.pypa.io/
 .. _PyPI: https://pypi.org/project/bioscan-dataset/
-.. _readthedocs: https://bioscan-dataset.readthedocs.io/en/v1.1.0/
+.. _readthedocs: https://bioscan-dataset.readthedocs.io

--- a/bioscan_dataset/__meta__.py
+++ b/bioscan_dataset/__meta__.py
@@ -1,6 +1,6 @@
 name = "bioscan-dataset"
 path = name.lower().replace("-", "_").replace(" ", "_")
-version = "1.0.1"
+version = "1.1.0"
 author = "Scott C. Lowe"
 author_email = "scott.code.lowe@gmail.com"
 description = "PyTorch torchvision-style datasets for BIOSCAN-1M and BIOSCAN-5M."

--- a/bioscan_dataset/__meta__.py
+++ b/bioscan_dataset/__meta__.py
@@ -1,6 +1,6 @@
 name = "bioscan-dataset"
 path = name.lower().replace("-", "_").replace(" ", "_")
-version = "1.1.0"
+version = "1.1.dev0"
 author = "Scott C. Lowe"
 author_email = "scott.code.lowe@gmail.com"
 description = "PyTorch torchvision-style datasets for BIOSCAN-1M and BIOSCAN-5M."


### PR DESCRIPTION
Add v1.1.0 to the changelog, and update the version number when installing from github to v1.1.dev0 to indicate it is unstable.

The release has already been pushed to [PyPI](https://pypi.org/project/bioscan-dataset/1.1.0/), [GitHub](https://github.com/bioscan-ml/dataset/releases/tag/v1.1.0), and [readthedocs](https://bioscan-dataset.readthedocs.io/en/v1.1.0/).