### PR TITLE
ENH: Add support for CLIBD partitioning to BIOSCAN-1M

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -321,6 +321,24 @@ If you make use of the BIOSCAN-1M or BIOSCAN-5M datasets in your research, pleas
       url={https://proceedings.neurips.cc/paper_files/paper/2023/file/87dbbdc3a685a97ad28489a1d57c45c1-Paper-Datasets_and_Benchmarks.pdf},
    }
 
+If you use the CLIBD partitioning scheme for BIOSCAN-1M, please also consider citing the `CLIBD paper <https://arxiv.org/abs/2405.17537>`_.
+
+.. code-block:: bibtex
+
+   @article{clibd,
+      title={{CLIBD}: Bridging Vision and Genomics for Biodiversity Monitoring at Scale},
+      author={Gong, ZeMing and Wang, Austin T. and Huo, Xiaoliang
+         and Haurum, Joakim Bruslund and Lowe, Scott C. and Taylor, Graham W.
+         and Chang, Angel X.
+      },
+      journal={arXiv preprint arXiv:2405.17537},
+      year={2024},
+      eprint={2405.17537},
+      archivePrefix={arXiv},
+      primaryClass={cs.AI},
+      doi={10.48550/arxiv.2405.17537},
+   }
+
 .. _BIOSCAN Browser: https://bioscan-browser.netlify.app/
 .. _BIOSCAN-1M paper: https://papers.nips.cc/paper_files/paper/2023/hash/87dbbdc3a685a97ad28489a1d57c45c1-Abstract-Datasets_and_Benchmarks.html
 .. _BIOSCAN-5M paper: https://arxiv.org/abs/2406.12723

--- a/bioscan_dataset/bioscan1m.py
+++ b/bioscan_dataset/bioscan1m.py
@@ -226,6 +226,10 @@ class BIOSCAN1M(VisionDataset):
         - ``"test"``
         - ``"no_split"``
 
+        Note that the contents of the split depends on the value of ``partitioning_version``.
+        If ``partitioning_version`` is changed, the same ``split`` value will yield
+        completely different records.
+
     partitioning_version : str, default="large_diptera_family"
         The dataset partitioning version, one of:
 

--- a/bioscan_dataset/bioscan1m.py
+++ b/bioscan_dataset/bioscan1m.py
@@ -174,6 +174,9 @@ def load_bioscan1m_metadata(
         <https://arxiv.org/abs/2405.17537>`__, whilst the other partitions were
         introduced in the `BIOSCAN-1M paper <https://arxiv.org/abs/2307.10455>`__.
 
+        To use the CLIBD partitioning, download and extract the partition files from
+        `here <https://huggingface.co/datasets/bioscan-ml/bioscan-clibd/resolve/335f24b/data/BIOSCAN_1M/CLIBD_partitioning.zip>`__.
+
         .. versionchanged:: 1.2.0
             Added support for CLIBD partitioning.
 
@@ -188,7 +191,7 @@ def load_bioscan1m_metadata(
     -------
     df : pandas.DataFrame
         The metadata DataFrame.
-    """
+    """  # noqa: E501
     if dtype == MetadataDtype.DEFAULT:
         # Use our default column data types
         dtype = COLUMN_DTYPES
@@ -327,6 +330,10 @@ class BIOSCAN1M(VisionDataset):
         <https://arxiv.org/abs/2405.17537>`__, whilst the other partitions were
         introduced in the `BIOSCAN-1M paper <https://arxiv.org/abs/2307.10455>`__.
 
+        To use the CLIBD partitioning, download and extract the partition files from
+        `here <https://huggingface.co/datasets/bioscan-ml/bioscan-clibd/resolve/335f24b/data/BIOSCAN_1M/CLIBD_partitioning.zip>`__
+        into the ``root`` directory.
+
         .. versionchanged:: 1.2.0
             Added support for CLIBD partitioning.
 
@@ -388,7 +395,7 @@ class BIOSCAN1M(VisionDataset):
 
     target_transform : Callable, default=None
         Label transformation pipeline.
-    """
+    """  # noqa: E501
 
     def __init__(
         self,


### PR DESCRIPTION
This adds support for using the partitions introduced by the [CLIBD paper](https://openreview.net/forum?id=d5HUnyByAI) for BIOSCAN-1M.

The CLIBD partitions can be [downloaded here](https://huggingface.co/datasets/bioscan-ml/bioscan-clibd/resolve/335f24b/data/BIOSCAN_1M/CLIBD_partitioning.zip). This is documented in the API documentation (which is the only place the CLIBD partitions are documented at the moment).

Closes #20.