### PR TITLE
MNT: Improve error handling for bad split and partitioning version names

### DIFF
--- a/bioscan_dataset/bioscan1m.py
+++ b/bioscan_dataset/bioscan1m.py
@@ -283,7 +283,7 @@ def load_bioscan1m_metadata(
             if split not in CLIBD_VALID_SPLITS:
                 raise ValueError(
                     f"Invalid split value: '{split}'. Valid splits for partitioning version"
-                    f" '{partitioning_version}' are: {['all'] + CLIBD_VALID_SPLITS}"
+                    f" '{partitioning_version}' are: {', '.join(repr(s) for s in ['all'] + CLIBD_VALID_SPLITS)}"
                 ) from None
             raise
         # Use the order of samples from the CLIBD partitioning files
@@ -295,14 +295,14 @@ def load_bioscan1m_metadata(
             if partitioning_version not in PARTITIONING_VERSIONS:
                 raise ValueError(
                     f"Invalid partitioning version: '{partitioning_version}'."
-                    f" Valid partitioning versions are: {PARTITIONING_VERSIONS}"
+                    f" Valid partitioning versions are: {', '.join(repr(s) for s in PARTITIONING_VERSIONS)}"
                 ) from None
             raise
         df = df.loc[select]
     else:
         raise ValueError(
             f"Invalid split value: '{split}'. Valid splits for partitioning version"
-            f" '{partitioning_version}' are: {['all'] + VALID_SPLITS}"
+            f" '{partitioning_version}' are: {', '.join(repr(s) for s in ['all'] + VALID_SPLITS)}"
         )
     return df
 

--- a/bioscan_dataset/bioscan5m.py
+++ b/bioscan_dataset/bioscan5m.py
@@ -182,7 +182,10 @@ def load_bioscan5m_metadata(
     elif split in VALID_SPLITS:
         df = df[df["split"] == split]
     else:
-        raise ValueError(f"Unknown split: '{split}'. Must be one of: {['all', 'seen', 'unseen'] + VALID_SPLITS}")
+        raise ValueError(
+            f"Unknown split: '{split}'. Must be one of:"
+            f" {', '.join(repr(s) for s in ['all', 'seen', 'unseen'] + VALID_SPLITS)}"
+        )
     # Add index columns to use for targets
     label_cols = [
         "phylum",

--- a/bioscan_dataset/bioscan5m.py
+++ b/bioscan_dataset/bioscan5m.py
@@ -70,6 +70,7 @@ USECOLS = [
     "split",
 ]
 
+VALID_SPLITS = ["pretrain", "train", "val", "test", "key_unseen", "val_unseen", "test_unseen", "other_heldout"]
 SEEN_SPLITS = ["train", "val", "test"]
 UNSEEN_SPLITS = ["key_unseen", "val_unseen", "test_unseen"]
 
@@ -178,8 +179,10 @@ def load_bioscan5m_metadata(
         df = df[df["split"].isin(SEEN_SPLITS)]
     elif split == "unseen":
         df = df[df["split"].isin(UNSEEN_SPLITS)]
-    else:
+    elif split in VALID_SPLITS:
         df = df[df["split"] == split]
+    else:
+        raise ValueError(f"Unknown split: '{split}'. Must be one of: {['all', 'seen', 'unseen'] + VALID_SPLITS}")
     # Add index columns to use for targets
     label_cols = [
         "phylum",


### PR DESCRIPTION
Raise value errors that are more easily interpret by users than the opaque key error, file not found error, or silently returning an empty dataframe.