### PR TITLE
MNT: Vectorize image_path code

### DIFF
--- a/bioscan_dataset/bioscan5m.py
+++ b/bioscan_dataset/bioscan5m.py
@@ -200,7 +200,9 @@ def load_bioscan5m_metadata(
     for c in label_cols:
         df[c + "_index"] = df[c].cat.codes
     # Add path to image file
-    df["image_path"] = df.apply(get_image_path, axis=1)
+    maybe_chunk = df["chunk"].astype(str) + os.path.sep
+    maybe_chunk.where(df["chunk"].notna(), "", inplace=True)
+    df["image_path"] = df["split"] + os.path.sep + maybe_chunk + df["processid"] + ".jpg"
     return df
 
 


### PR DESCRIPTION
Using `df.apply` to process each row individually in order to generate the image_path column was taking 4 seconds for the train partition (10% of the total class instantiation time). This compute time scales linearly with the number of samples, so when using all partitions this was taking 45-50 seconds (55-75% of the total class instantiation time).

By vectorizing this code, it now only takes 1.6 seconds to add the image_path column even when using all partitions.