### PR TITLE
ENH: Add autodownload of BIOSCAN-1M dataset

### DIFF
--- a/bioscan_dataset/bioscan5m.py
+++ b/bioscan_dataset/bioscan5m.py
@@ -292,7 +292,7 @@ class BIOSCAN5M(VisionDataset):
         Label transformation pipeline.
 
     download : bool, default=False
-        If true, downloads the dataset from the internet and puts it in root directory.
+        If ``True``, downloads the dataset from the internet and puts it in root directory.
         If dataset is already downloaded, it is not downloaded again.
         Images are only downloaded if the ``"image"`` modality is requested.
         Note that only ``image_package=cropped_256`` is supported for automatic image download.


### PR DESCRIPTION
Supports both cropped_256 and original_256 image packages, with md5 checksums on the metadata, image package zip files, and four sample images.

Closes #19.