### PR TITLE
ENH: Add automatic download of CLIBD partitions

### DIFF
--- a/bioscan_dataset/bioscan1m.py
+++ b/bioscan_dataset/bioscan1m.py
@@ -577,6 +577,8 @@ class BIOSCAN1M(VisionDataset):
         "url": "https://huggingface.co/datasets/bioscan-ml/bioscan-clibd/resolve/335f24b/data/BIOSCAN_1M/CLIBD_partitioning.zip",  # noqa: E501
         "md5": "fc08444a47d1533d99a892287e174cc1",
         "files": [
+            ("all_keys.txt", "808644e06aa47c66e0262235dae6bbb0"),
+            ("no_split_and_seen_train.txt", "387fc460fee3e11a5d76971d235dbe17"),
             ("no_split.txt", "52d069b51527919257eeb2f46960b619"),
             ("seen_keys.txt", "d820f90f286233ea5e25162766fa2edc"),
             ("single_species.txt", "7eee9f7f4807da5806bc6d0b912536e0"),

--- a/bioscan_dataset/bioscan1m.py
+++ b/bioscan_dataset/bioscan1m.py
@@ -235,11 +235,13 @@ def load_bioscan1m_metadata(
             f"{partitioning_version} partitioning requested, but the corresponding"
             f" partitioning data could not be found at: {repr(clibd_partitioning_path)}"
         )
-    elif explicit_clibd_partitioning_path:
-        raise EnvironmentError(
-            f"The CLIBD partitioning data could not be found at the specified path: {repr(clibd_partitioning_path)}"
-        )
     else:
+        if explicit_clibd_partitioning_path:
+            warnings.warn(
+                f"The CLIBD partitioning data was not found at the specified path: {repr(clibd_partitioning_path)}",
+                UserWarning,
+                stacklevel=2,
+            )
         clibd_partitioning_path = None
 
     if partitioning_version == "clibd":


### PR DESCRIPTION
If `download=True`, CLIBD partitioning data is automatically downloaded from [here](https://huggingface.co/datasets/bioscan-ml/bioscan-clibd/resolve/335f24b/data/BIOSCAN_1M/CLIBD_partitioning.zip) when `partitioning_version="clibd"`. The partitioning data is verified with md5 checksums, like with the main BIOSCAN-1M metadata TSV file.

Also, the expected CLIBD partitioning path is changed from being in the same parent dir as the TSV file to the same parent dir as the images dir. This does not constitute an API change since CLIBD support is as yet unreleased.