### PR TITLE
MNT: Don't use npt.ArrayLike type hint

### DIFF
--- a/bioscan_dataset/bioscan1m.py
+++ b/bioscan_dataset/bioscan1m.py
@@ -13,7 +13,7 @@ import pathlib
 import warnings
 import zipfile
 from enum import Enum
-from typing import Any, Iterable, Optional, Tuple, Union
+from typing import Any, Iterable, List, Optional, Tuple, Union
 
 import numpy as np
 import numpy.typing as npt
@@ -688,7 +688,7 @@ class BIOSCAN1M(VisionDataset):
 
     def index2label(
         self,
-        index: Union[int, npt.ArrayLike],
+        index: Union[int, List[int], npt.NDArray[np.int_]],
         column: Optional[str] = None,
     ) -> Union[str, npt.NDArray[np.str_]]:
         r"""

--- a/bioscan_dataset/bioscan5m.py
+++ b/bioscan_dataset/bioscan5m.py
@@ -10,7 +10,7 @@ BIOSCAN-5M PyTorch Dataset.
 
 import os
 from enum import Enum
-from typing import Any, Iterable, Optional, Tuple, Union
+from typing import Any, Iterable, List, Optional, Tuple, Union
 
 import numpy as np
 import numpy.typing as npt
@@ -427,7 +427,7 @@ class BIOSCAN5M(VisionDataset):
 
     def index2label(
         self,
-        index: Union[int, npt.ArrayLike],
+        index: Union[int, List[int], npt.NDArray[np.int_]],
         column: Optional[str] = None,
     ) -> Union[str, npt.NDArray[np.str_]]:
         r"""


### PR DESCRIPTION
This generates an obnoxiously long list of options in the documentation. Instead we just specify a list of ints and a numpy array of ints in the type hint.

**Before** call signature in docstring:
> index2label(index: [int](https://docs.python.org/3/library/functions.html#int) | _Buffer | _SupportsArray[dtype[[Any](https://docs.python.org/3/library/typing.html#typing.Any)]] | _NestedSequence[_SupportsArray[dtype[[Any](https://docs.python.org/3/library/typing.html#typing.Any)]]] | [bool](https://docs.python.org/3/library/functions.html#bool) | [float](https://docs.python.org/3/library/functions.html#float) | [complex](https://docs.python.org/3/library/functions.html#complex) | [str](https://docs.python.org/3/library/stdtypes.html#str) | [bytes](https://docs.python.org/3/library/stdtypes.html#bytes) | _NestedSequence[[bool](https://docs.python.org/3/library/functions.html#bool) | [int](https://docs.python.org/3/library/functions.html#int) | [float](https://docs.python.org/3/library/functions.html#float) | [complex](https://docs.python.org/3/library/functions.html#complex) | [str](https://docs.python.org/3/library/stdtypes.html#str) | [bytes](https://docs.python.org/3/library/stdtypes.html#bytes)], column: [str](https://docs.python.org/3/library/stdtypes.html#str) | [None](https://docs.python.org/3/library/constants.html#None) = None) → [str](https://docs.python.org/3/library/stdtypes.html#str) | ndarray[[tuple](https://docs.python.org/3/library/stdtypes.html#tuple)[[int](https://docs.python.org/3/library/functions.html#int), ...], dtype[str_]]

**After** call signature in docstring:
> index2label(index: [Union](https://docs.python.org/3/library/typing.html#typing.Union)[[int](https://docs.python.org/3/library/functions.html#int), [List](https://docs.python.org/3/library/typing.html#typing.List)[[int](https://docs.python.org/3/library/functions.html#int)], ndarray[[Any](https://docs.python.org/3/library/typing.html#typing.Any), dtype[int64]]], column: [Optional](https://docs.python.org/3/library/typing.html#typing.Optional)[[str](https://docs.python.org/3/library/stdtypes.html#str)] = None) → [Union](https://docs.python.org/3/library/typing.html#typing.Union)[[str](https://docs.python.org/3/library/stdtypes.html#str), ndarray[[Any](https://docs.python.org/3/library/typing.html#typing.Any), dtype[str_]]]