### PR TITLE
MNT: Add prefix to BIOSCAN-1M image pkg zip files

### DIFF
--- a/bioscan_dataset/bioscan1m.py
+++ b/bioscan_dataset/bioscan1m.py
@@ -947,7 +947,7 @@ class BIOSCAN1M(VisionDataset):
                 " Please manually download and extract the zip files."
             )
         data = self.zip_files[self.image_package]
-        filename = os.path.basename(data["url"])
+        filename = "BIOSCAN_1M_" + os.path.basename(data["url"])
         download_url(data["url"], self.root, filename=filename, md5=data.get("md5"))
         archive = os.path.join(self.root, filename)
         extract_zip_without_prefix(


### PR DESCRIPTION
This will help make it clearer that the files (named e.g. `"cropped_256.zip"` at the source URL) are for BIOSCAN-1M. We copy the prefix format used for BIOSCAN-5M, which is `"BIOSCAN_5M_"`, and so use `"BIOSCAN_1M_"`.