### PR TITLE
BUG+ENH: Correct BIOSCAN-1M validation split name

### DIFF
--- a/bioscan_dataset/bioscan1m.py
+++ b/bioscan_dataset/bioscan1m.py
@@ -84,19 +84,11 @@ PARTITIONING_VERSIONS = [
 ]
 
 VALID_SPLITS = ["train", "validation", "test", "no_split"]
+SPLIT_ALIASES = {"val": "validation"}
 VALID_METASPLITS = ["all"]
-PARTITION_ALIASES = {"val": "validation"}
 
 CLIBD_PARTITIONING_DIRNAME = "CLIBD_partitioning"
 
-CLIBD_PARTITION_ALIASES = {
-    "pretrain": "no_split",
-    "train": "train_seen",
-    "val": "val_seen",
-    "validation": "val_seen",
-    "test": "test_seen",
-    "key_unseen": "test_unseen_keys",
-}
 CLIBD_VALID_SPLITS = [
     "no_split",
     "seen_keys",
@@ -109,6 +101,14 @@ CLIBD_VALID_SPLITS = [
     "val_unseen",
     "val_unseen_keys",
 ]
+CLIBD_SPLIT_ALIASES = {
+    "pretrain": "no_split",
+    "train": "train_seen",
+    "val": "val_seen",
+    "validation": "val_seen",
+    "test": "test_seen",
+    "key_unseen": "test_unseen_keys",
+}
 CLIBD_VALID_METASPLITS = [
     "all",
     "all_keys",
@@ -248,10 +248,10 @@ def load_bioscan1m_metadata(
 
     if partitioning_version == "clibd":
         # Handle BIOSCAN-5M partition names as aliases for CLIBD partitions
-        split = CLIBD_PARTITION_ALIASES.get(split, split)
+        split = CLIBD_SPLIT_ALIASES.get(split, split)
     else:
         # Handle BIOSCAN-5M partition names as aliases for BIOSCAN-1M partitions
-        split = PARTITION_ALIASES.get(split, split)
+        split = SPLIT_ALIASES.get(split, split)
 
     df = pandas.read_csv(metadata_path, sep="\t", dtype=dtype, **kwargs)
     # Taxonomic label column names
@@ -639,9 +639,9 @@ class BIOSCAN1M(VisionDataset):
             self.clibd_partitioning_path = None
 
         if self.partitioning_version == "clibd":
-            self.split = CLIBD_PARTITION_ALIASES.get(split, split)
+            self.split = CLIBD_SPLIT_ALIASES.get(split, split)
         else:
-            self.split = PARTITION_ALIASES.get(split, split)
+            self.split = SPLIT_ALIASES.get(split, split)
         self.target_format = target_format
         self.reduce_repeated_barcodes = reduce_repeated_barcodes
         self.max_nucleotides = max_nucleotides

--- a/bioscan_dataset/bioscan1m.py
+++ b/bioscan_dataset/bioscan1m.py
@@ -85,6 +85,7 @@ PARTITIONING_VERSIONS = [
 
 VALID_SPLITS = ["train", "validation", "test", "no_split"]
 VALID_METASPLITS = ["all"]
+PARTITION_ALIASES = {"val": "validation"}
 
 CLIBD_PARTITIONING_DIRNAME = "CLIBD_partitioning"
 
@@ -247,6 +248,9 @@ def load_bioscan1m_metadata(
     if partitioning_version == "clibd":
         # Handle BIOSCAN-5M partition names as aliases for CLIBD partitions
         split = CLIBD_PARTITION_ALIASES.get(split, split)
+    else:
+        # Handle BIOSCAN-5M partition names as aliases for BIOSCAN-1M partitions
+        split = PARTITION_ALIASES.get(split, split)
 
     df = pandas.read_csv(metadata_path, sep="\t", dtype=dtype, **kwargs)
     # Taxonomic label column names
@@ -636,7 +640,7 @@ class BIOSCAN1M(VisionDataset):
         if self.partitioning_version == "clibd":
             self.split = CLIBD_PARTITION_ALIASES.get(split, split)
         else:
-            self.split = split
+            self.split = PARTITION_ALIASES.get(split, split)
         self.target_format = target_format
         self.reduce_repeated_barcodes = reduce_repeated_barcodes
         self.max_nucleotides = max_nucleotides

--- a/bioscan_dataset/bioscan1m.py
+++ b/bioscan_dataset/bioscan1m.py
@@ -83,7 +83,7 @@ PARTITIONING_VERSIONS = [
     "clibd",
 ]
 
-VALID_SPLITS = ["train", "val", "test", "no_split"]
+VALID_SPLITS = ["train", "validation", "test", "no_split"]
 VALID_METASPLITS = ["all"]
 
 CLIBD_PARTITIONING_DIRNAME = "CLIBD_partitioning"
@@ -154,7 +154,7 @@ def load_bioscan1m_metadata(
         should be one of:
 
         - ``"train"``
-        - ``"val"``
+        - ``"validation"``
         - ``"test"``
         - ``"no_split"``
 
@@ -418,7 +418,7 @@ class BIOSCAN1M(VisionDataset):
         should be one of:
 
         - ``"train"``
-        - ``"val"``
+        - ``"validation"``
         - ``"test"``
         - ``"no_split"``
 

--- a/bioscan_dataset/bioscan1m.py
+++ b/bioscan_dataset/bioscan1m.py
@@ -93,6 +93,7 @@ CLIBD_PARTITION_ALIASES = {
     "pretrain": "no_split",
     "train": "train_seen",
     "val": "val_seen",
+    "validation": "val_seen",
     "test": "test_seen",
     "key_unseen": "test_unseen_keys",
 }

--- a/bioscan_dataset/bioscan5m.py
+++ b/bioscan_dataset/bioscan5m.py
@@ -71,7 +71,7 @@ USECOLS = [
 ]
 
 VALID_SPLITS = ["pretrain", "train", "val", "test", "key_unseen", "val_unseen", "test_unseen", "other_heldout"]
-PARTITION_ALIASES = {"validation": "val"}
+SPLIT_ALIASES = {"validation": "val"}
 VALID_METASPLITS = ["all", "seen", "unseen"]
 SEEN_SPLITS = ["train", "val", "test"]
 UNSEEN_SPLITS = ["key_unseen", "val_unseen", "test_unseen"]
@@ -160,7 +160,7 @@ def load_bioscan5m_metadata(
         # Use our default column data types
         dtype = COLUMN_DTYPES
     # Handle BIOSCAN-1M partition names as aliases for BIOSCAN-5M partitions
-    split = PARTITION_ALIASES.get(split, split)
+    split = SPLIT_ALIASES.get(split, split)
     # Read the metadata CSV file
     df = pandas.read_csv(metadata_path, dtype=dtype, **kwargs)
     # Truncate the DNA barcodes to the specified length
@@ -398,7 +398,7 @@ class BIOSCAN5M(VisionDataset):
         self.image_dir = os.path.join(self.root, self.base_folder, "images", self.image_package)
         self.metadata_path = os.path.join(self.root, self.base_folder, self.meta["filename"])
 
-        self.split = PARTITION_ALIASES.get(split, split)
+        self.split = SPLIT_ALIASES.get(split, split)
         self.target_format = target_format
         self.reduce_repeated_barcodes = reduce_repeated_barcodes
         self.max_nucleotides = max_nucleotides

--- a/bioscan_dataset/bioscan5m.py
+++ b/bioscan_dataset/bioscan5m.py
@@ -71,6 +71,7 @@ USECOLS = [
 ]
 
 VALID_SPLITS = ["pretrain", "train", "val", "test", "key_unseen", "val_unseen", "test_unseen", "other_heldout"]
+PARTITION_ALIASES = {"validation": "val"}
 VALID_METASPLITS = ["all", "seen", "unseen"]
 SEEN_SPLITS = ["train", "val", "test"]
 UNSEEN_SPLITS = ["key_unseen", "val_unseen", "test_unseen"]
@@ -158,6 +159,9 @@ def load_bioscan5m_metadata(
     if dtype == MetadataDtype.DEFAULT:
         # Use our default column data types
         dtype = COLUMN_DTYPES
+    # Handle BIOSCAN-1M partition names as aliases for BIOSCAN-5M partitions
+    split = PARTITION_ALIASES.get(split, split)
+    # Read the metadata CSV file
     df = pandas.read_csv(metadata_path, dtype=dtype, **kwargs)
     # Truncate the DNA barcodes to the specified length
     if max_nucleotides is not None:
@@ -394,7 +398,7 @@ class BIOSCAN5M(VisionDataset):
         self.image_dir = os.path.join(self.root, self.base_folder, "images", self.image_package)
         self.metadata_path = os.path.join(self.root, self.base_folder, self.meta["filename"])
 
-        self.split = split
+        self.split = PARTITION_ALIASES.get(split, split)
         self.target_format = target_format
         self.reduce_repeated_barcodes = reduce_repeated_barcodes
         self.max_nucleotides = max_nucleotides


### PR DESCRIPTION
The split is called `"validation"`, not `"val"`. Bug was introduced in #27 (and was caught before release).

Since others will doubtlessly make the same mistake, I have added support for val as an alias to validation in BIOSCAN1M, and for validation as an alias to val in BIOSCAN5M.