### PR TITLE
API: Add `__all__` to restrain `import *`

### DIFF
--- a/bioscan_dataset/__init__.py
+++ b/bioscan_dataset/__init__.py
@@ -2,5 +2,7 @@ from . import __meta__
 
 __version__ = __meta__.version
 
+__all__ = ["BIOSCAN1M", "BIOSCAN5M", "load_bioscan1m_metadata", "load_bioscan5m_metadata"]
+
 from .bioscan1m import BIOSCAN1M, load_bioscan1m_metadata
 from .bioscan5m import BIOSCAN5M, load_bioscan5m_metadata

--- a/bioscan_dataset/bioscan1m.py
+++ b/bioscan_dataset/bioscan1m.py
@@ -23,6 +23,8 @@ import torch
 from torchvision.datasets.utils import check_integrity, download_url
 from torchvision.datasets.vision import VisionDataset
 
+__all__ = ["BIOSCAN1M", "load_bioscan1m_metadata"]
+
 RGB_MEAN = torch.tensor([0.72510918, 0.72891550, 0.72956181])
 RGB_STDEV = torch.tensor([0.12654378, 0.14301962, 0.16103319])
 

--- a/bioscan_dataset/bioscan5m.py
+++ b/bioscan_dataset/bioscan5m.py
@@ -20,6 +20,8 @@ import torch
 from torchvision.datasets.utils import check_integrity, download_and_extract_archive
 from torchvision.datasets.vision import VisionDataset
 
+__all__ = ["BIOSCAN5M", "load_bioscan5m_metadata"]
+
 RGB_MEAN = torch.tensor([0.76281859, 0.76503749, 0.76373138])
 RGB_STDEV = torch.tensor([0.14205404, 0.15642502, 0.17309470])
 


### PR DESCRIPTION
This ensures `from x import *` only imports our API functions and classes into the local namespace, avoiding clobbering or conflicting names being imported.

Many constants (e.g. RGB_MEAN) are present in both bioscan1m and bioscan5m with the same name in each.