### PR TITLE
API: Expand columns in dataset.metadata

### DIFF
--- a/bioscan_dataset/bioscan1m.py
+++ b/bioscan_dataset/bioscan1m.py
@@ -58,6 +58,7 @@ COLUMN_DTYPES = {
 }
 
 USECOLS = [
+    "processid",
     "sampleid",
     "uri",
     "phylum",

--- a/bioscan_dataset/bioscan5m.py
+++ b/bioscan_dataset/bioscan5m.py
@@ -67,6 +67,8 @@ USECOLS = [
     "coord-lat",
     "coord-lon",
     "image_measurement_value",
+    "area_fraction",
+    "scale_factor",
     "split",
 ]
 


### PR DESCRIPTION
- Add `"processid"` to bioscan1m's `USECOLS`.
- Add `"area_fraction"` and `"scale_factor"` to bioscan5m's `USECOLS`.

These changes make these columns available in the dataset.metadata attribute after instantiating the class, so that users can compare records between BIOSCAN1M and BIOSCAN5M based on the processid and so users can utilize the area_fraction and scale_factor data as additional modality options.