### PR TITLE
REL: Release version 1.2.0

### DIFF
--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -11,6 +11,74 @@ The format is based on `Keep a Changelog`_, and this project adheres to `Semanti
 Categories for changes are: Added, Changed, Deprecated, Removed, Fixed, Security.
 
 
+Version `1.2.0 <https://github.com/bioscan-ml/dataset/tree/v1.2.0>`__
+---------------------------------------------------------------------
+
+Release date: 2025-04-03.
+`Full commit changelog <https://github.com/bioscan-ml/dataset/compare/v1.1.0...v1.2.0>`__.
+
+This is a minor release adding some new features.
+In particular, CLIBD partitioning of BIOSCAN-1M is now supported, automatic download of BIOSCAN-1M is now supported, and multiple splits can be loaded at once by joining them with ``"+"`` such as ``"pretrain+train"``.
+
+.. _v1.2.0 Changed:
+
+Fixed
+~~~~~
+
+-   Sped up BIOSCAN5M load times by vectorizing the image path generation process
+    (`#28 <https://github.com/bioscan-ml/dataset/pull/28>`__).
+
+-   Avoid re-download and re-extraction of splits which were already correctly present, which previously could be triggered by other splits needing to be downloaded, for example when using metasplit ``"seen"`` or ``"all"`` when some (but not all) splits were already downloaded
+    (`#40 <https://github.com/bioscan-ml/dataset/pull/40>`__).
+
+.. _v1.2.0 Added:
+
+Added
+~~~~~
+
+-   Added support for `CLIBD <https://openreview.net/forum?id=d5HUnyByAI>`__ partitioning of BIOSCAN-1M, using argument ``partitioning_version="clibd"`` to BIOSCAN1M
+    (`#25 <https://github.com/bioscan-ml/dataset/pull/25>`__,
+    `#26 <https://github.com/bioscan-ml/dataset/pull/26>`__,
+    `#30 <https://github.com/bioscan-ml/dataset/pull/30>`__,
+    `#35 <https://github.com/bioscan-ml/dataset/pull/35>`__).
+
+-   Added automatic download support to BIOSCAN1M.
+    This includes both the metadata CSV and the image files (`#31 <https://github.com/bioscan-ml/dataset/pull/31>`__, `#37 <https://github.com/bioscan-ml/dataset/pull/37>`__), and the CLIBD partitioning data (`#33 <https://github.com/bioscan-ml/dataset/pull/33>`__).
+    As with BIOSCAN5M, data is lazily downloaded, so only additional files needed for the current dataset request are downloaded.
+
+-   Added support for combinations of splits being specified joined with ``"+"`` such as ``split="pretrain+train"``
+    (`#39 <https://github.com/bioscan-ml/dataset/pull/39>`__,
+    `#40 <https://github.com/bioscan-ml/dataset/pull/40>`__).
+
+-   Added aliasing between ``"val"`` (BIOSCAN-5M) and ``"validation"`` (BIOSCAN-1M) split names
+    (`#38 <https://github.com/bioscan-ml/dataset/pull/38>`__).
+
+-   Added ``__all__`` to better support ``from bioscan_dataset import *``
+    (`#41 <https://github.com/bioscan-ml/dataset/pull/41>`__).
+
+-   Added type hinting
+    (`#44 <https://github.com/bioscan-ml/dataset/pull/44>`__).
+
+-   Added access to columns ``"processid"`` in ``BIOSCAN1M.metadata`` and both ``"area_fraction"`` and ``"scale_factor"`` in ``BIOSCAN5M.metadata``
+    (`#43 <https://github.com/bioscan-ml/dataset/pull/43>`__).
+
+-   Added more detailed ``__repr__`` information, which is shown when printing the dataset object
+    (`#34 <https://github.com/bioscan-ml/dataset/pull/34>`__).
+
+-   Improved error messages for bad split values or partitioning versions
+    (`#27 <https://github.com/bioscan-ml/dataset/pull/27>`__,
+    `#32 <https://github.com/bioscan-ml/dataset/pull/32>`__).
+
+.. _v1.2.0 Documentation:
+
+Documentation
+~~~~~~~~~~~~~
+
+-   General documentation improvements
+    (`#42 <https://github.com/bioscan-ml/dataset/pull/42>`__,
+    `#44 <https://github.com/bioscan-ml/dataset/pull/44>`__).
+
+
 Version `1.1.0 <https://github.com/bioscan-ml/dataset/tree/v1.1.0>`__
 ---------------------------------------------------------------------
 

--- a/README.rst
+++ b/README.rst
@@ -3,7 +3,7 @@
     <p style="margin: 0;">
         <a href="https://pypi.org/project/bioscan-dataset/"><img alt="Latest PyPI release" src="https://img.shields.io/pypi/v/bioscan-dataset.svg" style="max-width: 100%;"></a>
         <a href="https://raw.githubusercontent.com/bioscan-ml/dataset/master/LICENSE"><img alt="MIT License" src="https://img.shields.io/pypi/l/bioscan-dataset" style="max-width: 100%;"></a>
-        <a href="https://bioscan-dataset.readthedocs.io/en/v1.2.0/"><img alt="Documentation" src="https://img.shields.io/badge/docs-readthedocs-blue" style="max-width: 100%;"></a>
+        <a href="https://bioscan-dataset.readthedocs.io"><img alt="Documentation" src="https://img.shields.io/badge/docs-readthedocs-blue" style="max-width: 100%;"></a>
         <a href="https://github.com/psf/black"><img alt="black" src="https://img.shields.io/badge/code%20style-black-000000.svg" style="max-width: 100%;"></a>
         <a href="https://github.com/pre-commit/pre-commit"><img alt="pre-commit enabled" src="https://img.shields.io/badge/pre--commit-enabled-brightgreen?logo=pre-commit&amp;logoColor=white" style="max-width: 100%;"></a>
         <a href="https://www.doi.org/10.48550/arxiv.2406.12723"><img alt="DOI" src="https://img.shields.io/badge/DOI-10.48550/arxiv.2406.12723-blue.svg" style="max-width: 100%;"></a>
@@ -357,11 +357,11 @@ If you use the CLIBD partitioning scheme for BIOSCAN-1M, please also consider ci
 .. _BIOSCAN Browser: https://bioscan-browser.netlify.app/
 .. _BIOSCAN-1M paper: https://papers.nips.cc/paper_files/paper/2023/hash/87dbbdc3a685a97ad28489a1d57c45c1-Abstract-Datasets_and_Benchmarks.html
 .. _BIOSCAN-5M paper: https://arxiv.org/abs/2406.12723
-.. _BS1M-class: https://bioscan-dataset.readthedocs.io/en/v1.2.0/api.html#bioscan_dataset.BIOSCAN1M
-.. _BS5M-class: https://bioscan-dataset.readthedocs.io/en/v1.2.0/api.html#bioscan_dataset.BIOSCAN5M
+.. _BS1M-class: https://bioscan-dataset.readthedocs.io/en/stable/api.html#bioscan_dataset.BIOSCAN1M
+.. _BS5M-class: https://bioscan-dataset.readthedocs.io/en/stable/api.html#bioscan_dataset.BIOSCAN5M
 .. _our repo: https://github.com/bioscan-ml/dataset
 .. _pip: https://pip.pypa.io/
 .. _PyPI: https://pypi.org/project/bioscan-dataset/
-.. _readthedocs: https://bioscan-dataset.readthedocs.io/en/v1.2.0/
+.. _readthedocs: https://bioscan-dataset.readthedocs.io
 .. _what-is-DNA-barcoding: https://www.ibol.org/phase1/about-us/what-is-dna-barcoding/
 .. _what-is-DNA-BIN: https://portal.boldsystems.org/bin

--- a/README.rst
+++ b/README.rst
@@ -3,7 +3,7 @@
     <p style="margin: 0;">
         <a href="https://pypi.org/project/bioscan-dataset/"><img alt="Latest PyPI release" src="https://img.shields.io/pypi/v/bioscan-dataset.svg" style="max-width: 100%;"></a>
         <a href="https://raw.githubusercontent.com/bioscan-ml/dataset/master/LICENSE"><img alt="MIT License" src="https://img.shields.io/pypi/l/bioscan-dataset" style="max-width: 100%;"></a>
-        <a href="https://bioscan-dataset.readthedocs.io"><img alt="Documentation" src="https://img.shields.io/badge/docs-readthedocs-blue" style="max-width: 100%;"></a>
+        <a href="https://bioscan-dataset.readthedocs.io/en/v1.2.0/"><img alt="Documentation" src="https://img.shields.io/badge/docs-readthedocs-blue" style="max-width: 100%;"></a>
         <a href="https://github.com/psf/black"><img alt="black" src="https://img.shields.io/badge/code%20style-black-000000.svg" style="max-width: 100%;"></a>
         <a href="https://github.com/pre-commit/pre-commit"><img alt="pre-commit enabled" src="https://img.shields.io/badge/pre--commit-enabled-brightgreen?logo=pre-commit&amp;logoColor=white" style="max-width: 100%;"></a>
         <a href="https://www.doi.org/10.48550/arxiv.2406.12723"><img alt="DOI" src="https://img.shields.io/badge/DOI-10.48550/arxiv.2406.12723-blue.svg" style="max-width: 100%;"></a>
@@ -357,11 +357,11 @@ If you use the CLIBD partitioning scheme for BIOSCAN-1M, please also consider ci
 .. _BIOSCAN Browser: https://bioscan-browser.netlify.app/
 .. _BIOSCAN-1M paper: https://papers.nips.cc/paper_files/paper/2023/hash/87dbbdc3a685a97ad28489a1d57c45c1-Abstract-Datasets_and_Benchmarks.html
 .. _BIOSCAN-5M paper: https://arxiv.org/abs/2406.12723
-.. _BS1M-class: https://bioscan-dataset.readthedocs.io/en/stable/api.html#bioscan_dataset.BIOSCAN1M
-.. _BS5M-class: https://bioscan-dataset.readthedocs.io/en/stable/api.html#bioscan_dataset.BIOSCAN5M
+.. _BS1M-class: https://bioscan-dataset.readthedocs.io/en/v1.2.0/api.html#bioscan_dataset.BIOSCAN1M
+.. _BS5M-class: https://bioscan-dataset.readthedocs.io/en/v1.2.0/api.html#bioscan_dataset.BIOSCAN5M
 .. _our repo: https://github.com/bioscan-ml/dataset
 .. _pip: https://pip.pypa.io/
 .. _PyPI: https://pypi.org/project/bioscan-dataset/
-.. _readthedocs: https://bioscan-dataset.readthedocs.io
+.. _readthedocs: https://bioscan-dataset.readthedocs.io/en/v1.2.0/
 .. _what-is-DNA-barcoding: https://www.ibol.org/phase1/about-us/what-is-dna-barcoding/
 .. _what-is-DNA-BIN: https://portal.boldsystems.org/bin

--- a/bioscan_dataset/__meta__.py
+++ b/bioscan_dataset/__meta__.py
@@ -1,6 +1,6 @@
 name = "bioscan-dataset"
 path = name.lower().replace("-", "_").replace(" ", "_")
-version = "1.2.0"
+version = "2.0.dev0"
 author = "Scott C. Lowe"
 author_email = "scott.code.lowe@gmail.com"
 description = "PyTorch torchvision-style datasets for BIOSCAN-1M and BIOSCAN-5M."

--- a/bioscan_dataset/__meta__.py
+++ b/bioscan_dataset/__meta__.py
@@ -1,6 +1,6 @@
 name = "bioscan-dataset"
 path = name.lower().replace("-", "_").replace(" ", "_")
-version = "1.1.dev0"
+version = "1.2.0"
 author = "Scott C. Lowe"
 author_email = "scott.code.lowe@gmail.com"
 description = "PyTorch torchvision-style datasets for BIOSCAN-1M and BIOSCAN-5M."


### PR DESCRIPTION
Add v1.2.0 to the changelog, and update the version number when installing from github to v2.0.dev0 to indicate it is unstable and we are working towards the next major release.

The release has already been pushed to [PyPI](https://pypi.org/project/bioscan-dataset/1.2.0/), [GitHub](https://github.com/bioscan-ml/dataset/releases/tag/v1.2.0), and [readthedocs](https://bioscan-dataset.readthedocs.io/en/v1.2.0/).