### PR TITLE
BUG: Fix handling of split=None

### DIFF
--- a/bioscan_dataset/bioscan1m.py
+++ b/bioscan_dataset/bioscan1m.py
@@ -150,6 +150,9 @@ def explode_metasplit(metasplit: str, partitioning_version: str, verify: bool = 
     >>> explode_metasplit("val", partitioning_version="clibd")
     {'val_seen'}
     """
+    if metasplit is None:
+        metasplit = "all"
+
     if partitioning_version == "clibd":
         _split_aliases = CLIBD_SPLIT_ALIASES
         _valid_splits = CLIBD_VALID_SPLITS

--- a/bioscan_dataset/bioscan5m.py
+++ b/bioscan_dataset/bioscan5m.py
@@ -469,7 +469,7 @@ class BIOSCAN5M(VisionDataset):
     def __init__(
         self,
         root,
-        split: Union[str, None] = "train",
+        split: str = "train",
         modality: Union[str, Iterable[str]] = ("image", "dna"),
         image_package: str = "cropped_256",
         reduce_repeated_barcodes: bool = False,

--- a/bioscan_dataset/bioscan5m.py
+++ b/bioscan_dataset/bioscan5m.py
@@ -110,6 +110,8 @@ def explode_metasplit(metasplit: str, verify: bool = False) -> Set[str]:
     >>> explode_metasplit("validation")
     {'val'}
     """
+    if metasplit is None:
+        metasplit = "all"
     split_list = [s.strip() for s in metasplit.split("+")]
     split_list = [SPLIT_ALIASES.get(s, s) for s in split_list]
     split_set = set(split_list)


### PR DESCRIPTION
This was not indicated as supported in the docstring, but was in the type hint. However, `BIOSCAN5M(..., split=None)` did not work because `explode_metasplit` expects a string.

Note that using `split=None` was not causing an issue for BIOSCAN1M, load_bioscan1m_metadata, or load_bioscan5m_metadata, because they don't call `explode_metasplit` when `split is None`. BIOSCAN5M was affected because it checks for images by split to facilitate lazy downloading.