### PR TITLE
DOC: Updates to documentation

### DIFF
--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -18,7 +18,7 @@ Release date: 2025-04-03.
 `Full commit changelog <https://github.com/bioscan-ml/dataset/compare/v1.1.0...v1.2.0>`__.
 
 This is a minor release adding some new features.
-In particular, CLIBD partitioning of BIOSCAN-1M is now supported, automatic download of BIOSCAN-1M is now supported, and multiple splits can be loaded at once by joining them with ``"+"`` such as ``"pretrain+train"``.
+In particular, CLIBD partitioning of BIOSCAN-1M is now supported, automatic download of BIOSCAN-1M is now supported, and multiple splits can be loaded at once by joining their names with ``"+"``, such as ``"pretrain+train"``.
 
 .. _v1.2.0 Changed:
 

--- a/README.rst
+++ b/README.rst
@@ -45,19 +45,7 @@ Usage
 -----
 
 The datasets can be used in the same way as PyTorch's `torchvision datasets <https://pytorch.org/vision/main/datasets.html#built-in-datasets>`__.
-For example, to load the BIOSCAN-1M dataset:
-
-.. code-block:: python
-
-    from bioscan_dataset import BIOSCAN1M
-
-    dataset = BIOSCAN1M(root="~/Datasets/bioscan/")
-
-    for image, dna_barcode, label in dataset:
-        # Do something with the image, dna_barcode, and label
-        pass
-
-To load the BIOSCAN-5M dataset:
+For example, to load the BIOSCAN-5M dataset:
 
 .. code-block:: python
 
@@ -69,6 +57,17 @@ To load the BIOSCAN-5M dataset:
         # Do something with the image, dna_barcode, and label
         pass
 
+To load the BIOSCAN-1M dataset:
+
+.. code-block:: python
+
+    from bioscan_dataset import BIOSCAN1M
+
+    dataset = BIOSCAN1M(root="~/Datasets/bioscan/")
+
+    for image, dna_barcode, label in dataset:
+        # Do something with the image, dna_barcode, and label
+        pass
 
 Note that although BIOSCAN-5M is a superset of BIOSCAN-1M, the repeated data samples are not identical between the two due to data cleaning and processing differences.
 Additionally, note that the splits are incompatible between the two datasets.

--- a/README.rst
+++ b/README.rst
@@ -70,8 +70,8 @@ To load the BIOSCAN-1M dataset:
         pass
 
 Note that although BIOSCAN-5M is a superset of BIOSCAN-1M, the repeated data samples are not identical between the two due to data cleaning and processing differences.
+For details, please see Appendix Q of the `BIOSCAN-5M paper`_.
 Additionally, note that the splits are incompatible between the two datasets.
-For details, see the `BIOSCAN-5M paper`_.
 
 For these reasons, we recommend new projects use the BIOSCAN-5M dataset over BIOSCAN-1M.
 
@@ -148,7 +148,7 @@ This partition can be used for training a novelty detector, without exposing the
 | heldout     | other_heldout       | novelty detector training         |      76,590 |     41,250 |     9,862 |
 +-------------+---------------------+-----------------------------------+-------------+------------+-----------+
 
-For more details about the BIOSCAN-5M partitioning, please see the `BIOSCAN-5M paper`_.
+For more details about the BIOSCAN-5M partitioning, please see Section 4.1 of the `BIOSCAN-5M paper`_.
 
 The dataset class also supports loading samples from multiple splits at once.
 This can be done by passing a single string containing multiple split names joined with ``"+"``.

--- a/bioscan_dataset/bioscan1m.py
+++ b/bioscan_dataset/bioscan1m.py
@@ -626,7 +626,7 @@ class BIOSCAN1M(VisionDataset):
         - ``"genus"``
         - ``"species"``
         - ``"uri"`` (equivalent to ``"dna_bin"``; a species-level label derived from
-          `clustering by BOLD <https://portal.boldsystems.org/bin>`_)
+          `DNA barcode clustering by BOLD <https://portal.boldsystems.org/bin>`_)
 
         Where ``"uri"`` corresponds to the BIN cluster label.
 

--- a/bioscan_dataset/bioscan5m.py
+++ b/bioscan_dataset/bioscan5m.py
@@ -357,7 +357,8 @@ class BIOSCAN5M(VisionDataset):
         - ``"subfamily"``
         - ``"genus"``
         - ``"species"``
-        - ``"dna_bin"`` (a species-level label derived from `clustering by BOLD <https://portal.boldsystems.org/bin>`_)
+        - ``"dna_bin"`` (a species-level label derived from
+          `DNA barcode clustering by BOLD <https://portal.boldsystems.org/bin>`_)
 
     target_format : str, default="index"
         Format in which the targets will be returned. One of:

--- a/bioscan_dataset/bioscan5m.py
+++ b/bioscan_dataset/bioscan5m.py
@@ -313,6 +313,13 @@ class BIOSCAN5M(VisionDataset):
         joined by ``"+"``. For example, ``split="pretrain+train"`` will return a dataset
         comprised of the pretraining and training partitions.
 
+        .. note::
+            There is distributional shift between the partitions, which means the
+            validation and test accuracy are not directly comparable, and the
+            accuracy for the seen and unseen splits are not directly comparable.
+            For more details, please see Appendix R.3 of the
+            `BIOSCAN-5M paper <https://arxiv.org/abs/2406.12723>`_.
+
     modality : str or Iterable[str], default=("image", "dna")
         Which data modalities to use. One of, or a list of:
         ``"image"``, ``"dna"``, or any column name in the metadata CSV file.


### PR DESCRIPTION
- Add note about distributional shift between BIOSCAN-5M splits to API documentation
- Add section references when directing reader to look at (parts of) the BIOSCAN-5M paper
- Clarify DNA BIN is a clustering of DNA barcodes
- Correction to v1.2.0 changelog