### PR TITLE
MNT: Clearer error messages when image files are missing

### DIFF
--- a/bioscan_dataset/bioscan1m.py
+++ b/bioscan_dataset/bioscan1m.py
@@ -812,7 +812,7 @@ class BIOSCAN1M(VisionDataset):
             self.download()
 
         if not self._check_integrity():
-            raise EnvironmentError(f"{type(self).__name__} dataset not found in {self.root}.")
+            raise EnvironmentError(f"{type(self).__name__} dataset not found, incomplete, or corrupted: {self.root}.")
 
         self._load_metadata()
 

--- a/bioscan_dataset/bioscan1m.py
+++ b/bioscan_dataset/bioscan1m.py
@@ -1010,16 +1010,20 @@ class BIOSCAN1M(VisionDataset):
                 check = check_integrity(file, data[self.image_package])
             else:
                 check = os.path.exists(file)
+            check_all &= check
             if verbose >= 1 and not check:
-                if not os.path.exists(os.path.dirname(file)):
+                if not os.path.exists(os.path.dirname(os.path.dirname(file))):
+                    print(f"Directory missing: {os.path.dirname(os.path.dirname(file))}")
+                    return False
+                elif not os.path.exists(os.path.dirname(file)):
                     print(f"Directory missing: {os.path.dirname(file)}")
+                    return False
                 elif not os.path.exists(file):
                     print(f"File missing: {file}")
                 else:
                     print(f"File invalid: {file}")
             if verbose >= 2 and check:
                 print(f"File present: {file}")
-            check_all &= check
         return check_all
 
     def _check_integrity_clibd_partitioning(self, verbose=1) -> bool:

--- a/bioscan_dataset/bioscan1m.py
+++ b/bioscan_dataset/bioscan1m.py
@@ -1059,6 +1059,8 @@ class BIOSCAN1M(VisionDataset):
             check &= self._check_integrity_images(verbose=verbose)
         if self.partitioning_version == "clibd":
             check &= self._check_integrity_clibd_partitioning(verbose=verbose)
+        if not check and verbose >= 1:
+            print(f"{type(self).__name__} dataset not found, incomplete, or corrupted.")
         return check
 
     def _download_metadata(self, verbose=1) -> None:

--- a/bioscan_dataset/bioscan1m.py
+++ b/bioscan_dataset/bioscan1m.py
@@ -999,6 +999,10 @@ class BIOSCAN1M(VisionDataset):
         return check
 
     def _check_integrity_images(self, verbose=1) -> bool:
+        if not os.path.isdir(self.image_dir):
+            if verbose >= 1:
+                print(f"Image directory missing: {self.image_dir}")
+            return False
         check_all = True
         for file, data in self.image_files:
             file = os.path.join(self.image_dir, file)
@@ -1007,7 +1011,9 @@ class BIOSCAN1M(VisionDataset):
             else:
                 check = os.path.exists(file)
             if verbose >= 1 and not check:
-                if not os.path.exists(file):
+                if not os.path.exists(os.path.dirname(file)):
+                    print(f"Directory missing: {os.path.dirname(file)}")
+                elif not os.path.exists(file):
                     print(f"File missing: {file}")
                 else:
                     print(f"File invalid: {file}")

--- a/bioscan_dataset/bioscan5m.py
+++ b/bioscan_dataset/bioscan5m.py
@@ -771,6 +771,8 @@ class BIOSCAN5M(VisionDataset):
         check &= self._check_integrity_metadata(verbose=verbose)
         if "image" in self.modality:
             check &= self._check_integrity_images(verbose=verbose)
+        if not check and verbose >= 1:
+            print(f"{type(self).__name__} dataset not found, incomplete, or corrupted.")
         return check
 
     def _download_metadata(self, verbose=1) -> None:

--- a/bioscan_dataset/bioscan5m.py
+++ b/bioscan_dataset/bioscan5m.py
@@ -726,6 +726,10 @@ class BIOSCAN5M(VisionDataset):
         return check
 
     def _check_integrity_images(self, split=None, verbose=1) -> bool:
+        if not os.path.isdir(self.image_dir):
+            if verbose >= 1:
+                print(f"Image directory missing: {self.image_dir}")
+            return False
         if split is None:
             split = self.split
         split_set = explode_metasplit(split, verify=True)
@@ -738,7 +742,9 @@ class BIOSCAN5M(VisionDataset):
                 else:
                     check = os.path.exists(file)
                 if verbose >= 1 and not check:
-                    if not os.path.exists(file):
+                    if not os.path.exists(os.path.dirname(file)):
+                        print(f"Directory missing: {os.path.dirname(file)}")
+                    elif not os.path.exists(file):
                         print(f"File missing: {file}")
                     else:
                         print(f"File invalid: {file}")

--- a/bioscan_dataset/bioscan5m.py
+++ b/bioscan_dataset/bioscan5m.py
@@ -525,7 +525,7 @@ class BIOSCAN5M(VisionDataset):
             self.download()
 
         if not self._check_integrity():
-            raise EnvironmentError(f"{type(self).__name__} dataset not found in {self.root}.")
+            raise EnvironmentError(f"{type(self).__name__} dataset not found, incomplete, or corrupted: {self.root}.")
 
         self._load_metadata()
 

--- a/bioscan_dataset/bioscan5m.py
+++ b/bioscan_dataset/bioscan5m.py
@@ -741,16 +741,20 @@ class BIOSCAN5M(VisionDataset):
                     check = check_integrity(file, data[self.image_package])
                 else:
                     check = os.path.exists(file)
+                check_all &= check
                 if verbose >= 1 and not check:
-                    if not os.path.exists(os.path.dirname(file)):
+                    if not os.path.exists(os.path.dirname(os.path.dirname(file))):
+                        print(f"Directory missing: {os.path.dirname(os.path.dirname(file))}")
+                        break
+                    elif not os.path.exists(os.path.dirname(file)):
                         print(f"Directory missing: {os.path.dirname(file)}")
+                        break
                     elif not os.path.exists(file):
                         print(f"File missing: {file}")
                     else:
                         print(f"File invalid: {file}")
                 if verbose >= 2 and check:
                     print(f"File present: {file}")
-                check_all &= check
         return check_all
 
     def _check_integrity(self, verbose=1) -> bool:


### PR DESCRIPTION
To ensure that users don't think there are only a couple of files missing when all images are missing, if a whole directory is missing we indicate that instead.