### PR TITLE
REL: Release version 1.2.1

### DIFF
--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -20,7 +20,7 @@ Release date: 2025-04-03.
 This is a minor release adding some new features.
 In particular, CLIBD partitioning of BIOSCAN-1M is now supported, automatic download of BIOSCAN-1M is now supported, and multiple splits can be loaded at once by joining their names with ``"+"``, such as ``"pretrain+train"``.
 
-.. _v1.2.0 Changed:
+.. _v1.2.0 Fixed:
 
 Fixed
 ~~~~~

--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -11,6 +11,36 @@ The format is based on `Keep a Changelog`_, and this project adheres to `Semanti
 Categories for changes are: Added, Changed, Deprecated, Removed, Fixed, Security.
 
 
+Version `1.2.1 <https://github.com/bioscan-ml/dataset/tree/v1.2.1>`__
+---------------------------------------------------------------------
+
+Release date: 2025-04-11.
+`Full commit changelog <https://github.com/bioscan-ml/dataset/compare/v1.2.0...v1.2.1>`__.
+
+This is a bugfix release which fixes minor issues.
+
+.. _v1.2.1 Fixed:
+
+Fixed
+~~~~~
+
+-   Fix handling of ``BIOSCAN5M(... split=None)``, which was indicated as supported in the type hint but didn't work any more due to updates in 1.2.0
+    (`#46 <https://github.com/bioscan-ml/dataset/pull/46>`__).
+    Now it actually does work, but isn't indicated as supported in the type hint anymore.
+
+-   Provide clearer error messages when some or all images are missing
+    (`#50 <https://github.com/bioscan-ml/dataset/pull/50>`__).
+
+.. _v1.2.1 Documentation:
+
+Documentation
+~~~~~~~~~~~~~
+
+-   General documentation improvements
+    (`#49 <https://github.com/bioscan-ml/dataset/pull/49>`__,
+    `#51 <https://github.com/bioscan-ml/dataset/pull/51>`__).
+
+
 Version `1.2.0 <https://github.com/bioscan-ml/dataset/tree/v1.2.0>`__
 ---------------------------------------------------------------------
 

--- a/README.rst
+++ b/README.rst
@@ -3,7 +3,7 @@
     <p style="margin: 0;">
         <a href="https://pypi.org/project/bioscan-dataset/"><img alt="Latest PyPI release" src="https://img.shields.io/pypi/v/bioscan-dataset.svg" style="max-width: 100%;"></a>
         <a href="https://raw.githubusercontent.com/bioscan-ml/dataset/master/LICENSE"><img alt="MIT License" src="https://img.shields.io/pypi/l/bioscan-dataset" style="max-width: 100%;"></a>
-        <a href="https://bioscan-dataset.readthedocs.io"><img alt="Documentation" src="https://img.shields.io/badge/docs-readthedocs-blue" style="max-width: 100%;"></a>
+        <a href="https://bioscan-dataset.readthedocs.io/en/v1.2.1/"><img alt="Documentation" src="https://img.shields.io/badge/docs-readthedocs-blue" style="max-width: 100%;"></a>
         <a href="https://github.com/psf/black"><img alt="black" src="https://img.shields.io/badge/code%20style-black-000000.svg" style="max-width: 100%;"></a>
         <a href="https://github.com/pre-commit/pre-commit"><img alt="pre-commit enabled" src="https://img.shields.io/badge/pre--commit-enabled-brightgreen?logo=pre-commit&amp;logoColor=white" style="max-width: 100%;"></a>
         <a href="https://www.doi.org/10.48550/arxiv.2406.12723"><img alt="DOI" src="https://img.shields.io/badge/DOI-10.48550/arxiv.2406.12723-blue.svg" style="max-width: 100%;"></a>
@@ -356,11 +356,11 @@ If you use the CLIBD partitioning scheme for BIOSCAN-1M, please also consider ci
 .. _BIOSCAN Browser: https://bioscan-browser.netlify.app/
 .. _BIOSCAN-1M paper: https://papers.nips.cc/paper_files/paper/2023/hash/87dbbdc3a685a97ad28489a1d57c45c1-Abstract-Datasets_and_Benchmarks.html
 .. _BIOSCAN-5M paper: https://arxiv.org/abs/2406.12723
-.. _BS1M-class: https://bioscan-dataset.readthedocs.io/en/stable/api.html#bioscan_dataset.BIOSCAN1M
-.. _BS5M-class: https://bioscan-dataset.readthedocs.io/en/stable/api.html#bioscan_dataset.BIOSCAN5M
+.. _BS1M-class: https://bioscan-dataset.readthedocs.io/en/v1.2.1/api.html#bioscan_dataset.BIOSCAN1M
+.. _BS5M-class: https://bioscan-dataset.readthedocs.io/en/v1.2.1/api.html#bioscan_dataset.BIOSCAN5M
 .. _our repo: https://github.com/bioscan-ml/dataset
 .. _pip: https://pip.pypa.io/
 .. _PyPI: https://pypi.org/project/bioscan-dataset/
-.. _readthedocs: https://bioscan-dataset.readthedocs.io
+.. _readthedocs: https://bioscan-dataset.readthedocs.io/en/v1.2.1/
 .. _what-is-DNA-barcoding: https://www.ibol.org/phase1/about-us/what-is-dna-barcoding/
 .. _what-is-DNA-BIN: https://portal.boldsystems.org/bin

--- a/README.rst
+++ b/README.rst
@@ -3,7 +3,7 @@
     <p style="margin: 0;">
         <a href="https://pypi.org/project/bioscan-dataset/"><img alt="Latest PyPI release" src="https://img.shields.io/pypi/v/bioscan-dataset.svg" style="max-width: 100%;"></a>
         <a href="https://raw.githubusercontent.com/bioscan-ml/dataset/master/LICENSE"><img alt="MIT License" src="https://img.shields.io/pypi/l/bioscan-dataset" style="max-width: 100%;"></a>
-        <a href="https://bioscan-dataset.readthedocs.io/en/v1.2.1/"><img alt="Documentation" src="https://img.shields.io/badge/docs-readthedocs-blue" style="max-width: 100%;"></a>
+        <a href="https://bioscan-dataset.readthedocs.io"><img alt="Documentation" src="https://img.shields.io/badge/docs-readthedocs-blue" style="max-width: 100%;"></a>
         <a href="https://github.com/psf/black"><img alt="black" src="https://img.shields.io/badge/code%20style-black-000000.svg" style="max-width: 100%;"></a>
         <a href="https://github.com/pre-commit/pre-commit"><img alt="pre-commit enabled" src="https://img.shields.io/badge/pre--commit-enabled-brightgreen?logo=pre-commit&amp;logoColor=white" style="max-width: 100%;"></a>
         <a href="https://www.doi.org/10.48550/arxiv.2406.12723"><img alt="DOI" src="https://img.shields.io/badge/DOI-10.48550/arxiv.2406.12723-blue.svg" style="max-width: 100%;"></a>
@@ -356,11 +356,11 @@ If you use the CLIBD partitioning scheme for BIOSCAN-1M, please also consider ci
 .. _BIOSCAN Browser: https://bioscan-browser.netlify.app/
 .. _BIOSCAN-1M paper: https://papers.nips.cc/paper_files/paper/2023/hash/87dbbdc3a685a97ad28489a1d57c45c1-Abstract-Datasets_and_Benchmarks.html
 .. _BIOSCAN-5M paper: https://arxiv.org/abs/2406.12723
-.. _BS1M-class: https://bioscan-dataset.readthedocs.io/en/v1.2.1/api.html#bioscan_dataset.BIOSCAN1M
-.. _BS5M-class: https://bioscan-dataset.readthedocs.io/en/v1.2.1/api.html#bioscan_dataset.BIOSCAN5M
+.. _BS1M-class: https://bioscan-dataset.readthedocs.io/en/stable/api.html#bioscan_dataset.BIOSCAN1M
+.. _BS5M-class: https://bioscan-dataset.readthedocs.io/en/stable/api.html#bioscan_dataset.BIOSCAN5M
 .. _our repo: https://github.com/bioscan-ml/dataset
 .. _pip: https://pip.pypa.io/
 .. _PyPI: https://pypi.org/project/bioscan-dataset/
-.. _readthedocs: https://bioscan-dataset.readthedocs.io/en/v1.2.1/
+.. _readthedocs: https://bioscan-dataset.readthedocs.io
 .. _what-is-DNA-barcoding: https://www.ibol.org/phase1/about-us/what-is-dna-barcoding/
 .. _what-is-DNA-BIN: https://portal.boldsystems.org/bin

--- a/bioscan_dataset/__meta__.py
+++ b/bioscan_dataset/__meta__.py
@@ -1,6 +1,6 @@
 name = "bioscan-dataset"
 path = name.lower().replace("-", "_").replace(" ", "_")
-version = "1.2.dev0"
+version = "1.2.1"
 author = "Scott C. Lowe"
 author_email = "scott.code.lowe@gmail.com"
 description = "PyTorch torchvision-style datasets for BIOSCAN-1M and BIOSCAN-5M."

--- a/bioscan_dataset/__meta__.py
+++ b/bioscan_dataset/__meta__.py
@@ -1,6 +1,6 @@
 name = "bioscan-dataset"
 path = name.lower().replace("-", "_").replace(" ", "_")
-version = "1.2.1"
+version = "1.2.dev1"
 author = "Scott C. Lowe"
 author_email = "scott.code.lowe@gmail.com"
 description = "PyTorch torchvision-style datasets for BIOSCAN-1M and BIOSCAN-5M."


### PR DESCRIPTION
Add v1.2.1 to the changelog, and update the version number when installing from github to v1.2.dev1 to indicate it is unstable.

The release has already been pushed to [PyPI](https://pypi.org/project/bioscan-dataset/1.2.1/), [GitHub](https://github.com/bioscan-ml/dataset/releases/tag/v1.2.1), and [readthedocs](https://bioscan-dataset.readthedocs.io/en/v1.2.1/).

Also noticed a v1.2.0 anchor in the Changelog was incorrect while drafting this release, so put that in this PR too.