### PR TITLE
MNT: Clearer error for index2label/label2index called wrong way

### DIFF
--- a/bioscan_dataset/bioscan1m.py
+++ b/bioscan_dataset/bioscan1m.py
@@ -855,6 +855,11 @@ class BIOSCAN1M(VisionDataset):
             if index < 0:
                 return ""
             return self.metadata[column].cat.categories[index]
+        if isinstance(index, str):
+            raise TypeError(
+                f"index must be an int or array-like of ints, not a string: {repr(index)}."
+                " Did you mean to call label2index?"
+            )
         index = np.asarray(index)
         out = self.metadata[column].cat.categories[index]
         out = np.asarray(out)
@@ -903,6 +908,11 @@ class BIOSCAN1M(VisionDataset):
                 return self.metadata[column].cat.categories.get_loc(label)
             except KeyError:
                 raise KeyError(f"Label {repr(label)} not found in metadata column {repr(column)}") from None
+        if isinstance(label, (int, np.integer)):
+            raise TypeError(
+                f"label must be a string or list of strings, not an int: {repr(label)}."
+                " Did you mean to call index2label?"
+            )
         labels = label
         try:
             out = [-1 if lab == "" else self.metadata[column].cat.categories.get_loc(lab) for lab in labels]

--- a/bioscan_dataset/bioscan5m.py
+++ b/bioscan_dataset/bioscan5m.py
@@ -576,6 +576,11 @@ class BIOSCAN5M(VisionDataset):
             if index < 0:
                 return ""
             return self.metadata[column].cat.categories[index]
+        if isinstance(index, str):
+            raise TypeError(
+                f"index must be an int or array-like of ints, not a string: {repr(index)}."
+                " Did you mean to call label2index?"
+            )
         index = np.asarray(index)
         out = self.metadata[column].cat.categories[index]
         out = np.asarray(out)
@@ -631,6 +636,11 @@ class BIOSCAN5M(VisionDataset):
                 return self.metadata[column].cat.categories.get_loc(label)
             except KeyError:
                 raise KeyError(f"Label {repr(label)} not found in metadata column {repr(column)}") from None
+        if isinstance(label, (int, np.integer)):
+            raise TypeError(
+                f"label must be a string or list of strings, not an int: {repr(label)}."
+                " Did you mean to call index2label?"
+            )
         labels = label
         try:
             out = [-1 if lab == "" else self.metadata[column].cat.categories.get_loc(lab) for lab in labels]


### PR DESCRIPTION
If the user calls index2label on a string or label2index on an int, it is likely they meant to call the other function so we give a helpful error message to flag this specifically.