### PR TITLE
REL: Release version 1.3.0

### DIFF
--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -11,6 +11,41 @@ The format is based on `Keep a Changelog`_, and this project adheres to `Semanti
 Categories for changes are: Added, Changed, Deprecated, Removed, Fixed, Security.
 
 
+Version `1.3.0 <https://github.com/bioscan-ml/dataset/tree/v1.3.0>`__
+---------------------------------------------------------------------
+
+Release date: 2025-04-19.
+`Full commit changelog <https://github.com/bioscan-ml/dataset/compare/v1.2.1...v1.3.0>`__.
+
+This is a minor release which adds support for dictionary output format.
+
+.. _v1.3.0 Added:
+
+Added
+~~~~~
+
+-   Add support for dictionary outputs to ``__getitem__``, which is enabled by setting new parameter ``output_format`` to ``"dict"``
+    (`#53 <https://github.com/bioscan-ml/dataset/pull/53>`__).
+    The tuple output format, enabled by setting ``output_format="tuple"``, remains the default behaviour.
+
+.. _v1.3.0 Fixed:
+
+Fixed
+~~~~~
+
+-   Add support for NaN inputs to ``BIOSCAN1M.label2index`` and ``BIOSCAN5M.label2index``
+    (`#55 <https://github.com/bioscan-ml/dataset/pull/55>`__).
+    This addresses the fact that missing labels in the taxonomic columns are returned as NaN, which was not supported in the previous version.
+
+.. _v1.3.0 Documentation:
+
+Documentation
+~~~~~~~~~~~~~
+
+-   Add a usage example for ``target_transform`` to the usage guide
+    (`#56 <https://github.com/bioscan-ml/dataset/pull/56>`__).
+
+
 Version `1.2.1 <https://github.com/bioscan-ml/dataset/tree/v1.2.1>`__
 ---------------------------------------------------------------------
 

--- a/README.rst
+++ b/README.rst
@@ -3,7 +3,7 @@
     <p style="margin: 0;">
         <a href="https://pypi.org/project/bioscan-dataset/"><img alt="Latest PyPI release" src="https://img.shields.io/pypi/v/bioscan-dataset.svg" style="max-width: 100%;"></a>
         <a href="https://raw.githubusercontent.com/bioscan-ml/dataset/master/LICENSE"><img alt="MIT License" src="https://img.shields.io/pypi/l/bioscan-dataset" style="max-width: 100%;"></a>
-        <a href="https://bioscan-dataset.readthedocs.io"><img alt="Documentation" src="https://img.shields.io/badge/docs-readthedocs-blue" style="max-width: 100%;"></a>
+        <a href="https://bioscan-dataset.readthedocs.io/en/v1.3.0/"><img alt="Documentation" src="https://img.shields.io/badge/docs-readthedocs-blue" style="max-width: 100%;"></a>
         <a href="https://github.com/psf/black"><img alt="black" src="https://img.shields.io/badge/code%20style-black-000000.svg" style="max-width: 100%;"></a>
         <a href="https://github.com/pre-commit/pre-commit"><img alt="pre-commit enabled" src="https://img.shields.io/badge/pre--commit-enabled-brightgreen?logo=pre-commit&amp;logoColor=white" style="max-width: 100%;"></a>
         <a href="https://www.doi.org/10.48550/arxiv.2406.12723"><img alt="DOI" src="https://img.shields.io/badge/DOI-10.48550/arxiv.2406.12723-blue.svg" style="max-width: 100%;"></a>
@@ -411,12 +411,12 @@ If you use the CLIBD partitioning scheme for BIOSCAN-1M, please also consider ci
 .. _BIOSCAN Browser: https://bioscan-browser.netlify.app/
 .. _BIOSCAN-1M paper: https://papers.nips.cc/paper_files/paper/2023/hash/87dbbdc3a685a97ad28489a1d57c45c1-Abstract-Datasets_and_Benchmarks.html
 .. _BIOSCAN-5M paper: https://arxiv.org/abs/2406.12723
-.. _BS1M-class: https://bioscan-dataset.readthedocs.io/en/stable/api.html#bioscan_dataset.BIOSCAN1M
-.. _BS5M-class: https://bioscan-dataset.readthedocs.io/en/stable/api.html#bioscan_dataset.BIOSCAN5M
+.. _BS1M-class: https://bioscan-dataset.readthedocs.io/en/v1.3.0/api.html#bioscan_dataset.BIOSCAN1M
+.. _BS5M-class: https://bioscan-dataset.readthedocs.io/en/v1.3.0/api.html#bioscan_dataset.BIOSCAN5M
 .. _CLIBD paper: https://arxiv.org/abs/2405.17537
 .. _our repo: https://github.com/bioscan-ml/dataset
 .. _pip: https://pip.pypa.io/
 .. _PyPI: https://pypi.org/project/bioscan-dataset/
-.. _readthedocs: https://bioscan-dataset.readthedocs.io
+.. _readthedocs: https://bioscan-dataset.readthedocs.io/en/v1.3.0/
 .. _what-is-DNA-barcoding: https://www.ibol.org/phase1/about-us/what-is-dna-barcoding/
 .. _what-is-DNA-BIN: https://portal.boldsystems.org/bin

--- a/README.rst
+++ b/README.rst
@@ -3,7 +3,7 @@
     <p style="margin: 0;">
         <a href="https://pypi.org/project/bioscan-dataset/"><img alt="Latest PyPI release" src="https://img.shields.io/pypi/v/bioscan-dataset.svg" style="max-width: 100%;"></a>
         <a href="https://raw.githubusercontent.com/bioscan-ml/dataset/master/LICENSE"><img alt="MIT License" src="https://img.shields.io/pypi/l/bioscan-dataset" style="max-width: 100%;"></a>
-        <a href="https://bioscan-dataset.readthedocs.io/en/v1.3.0/"><img alt="Documentation" src="https://img.shields.io/badge/docs-readthedocs-blue" style="max-width: 100%;"></a>
+        <a href="https://bioscan-dataset.readthedocs.io"><img alt="Documentation" src="https://img.shields.io/badge/docs-readthedocs-blue" style="max-width: 100%;"></a>
         <a href="https://github.com/psf/black"><img alt="black" src="https://img.shields.io/badge/code%20style-black-000000.svg" style="max-width: 100%;"></a>
         <a href="https://github.com/pre-commit/pre-commit"><img alt="pre-commit enabled" src="https://img.shields.io/badge/pre--commit-enabled-brightgreen?logo=pre-commit&amp;logoColor=white" style="max-width: 100%;"></a>
         <a href="https://www.doi.org/10.48550/arxiv.2406.12723"><img alt="DOI" src="https://img.shields.io/badge/DOI-10.48550/arxiv.2406.12723-blue.svg" style="max-width: 100%;"></a>
@@ -411,12 +411,12 @@ If you use the CLIBD partitioning scheme for BIOSCAN-1M, please also consider ci
 .. _BIOSCAN Browser: https://bioscan-browser.netlify.app/
 .. _BIOSCAN-1M paper: https://papers.nips.cc/paper_files/paper/2023/hash/87dbbdc3a685a97ad28489a1d57c45c1-Abstract-Datasets_and_Benchmarks.html
 .. _BIOSCAN-5M paper: https://arxiv.org/abs/2406.12723
-.. _BS1M-class: https://bioscan-dataset.readthedocs.io/en/v1.3.0/api.html#bioscan_dataset.BIOSCAN1M
-.. _BS5M-class: https://bioscan-dataset.readthedocs.io/en/v1.3.0/api.html#bioscan_dataset.BIOSCAN5M
+.. _BS1M-class: https://bioscan-dataset.readthedocs.io/en/stable/api.html#bioscan_dataset.BIOSCAN1M
+.. _BS5M-class: https://bioscan-dataset.readthedocs.io/en/stable/api.html#bioscan_dataset.BIOSCAN5M
 .. _CLIBD paper: https://arxiv.org/abs/2405.17537
 .. _our repo: https://github.com/bioscan-ml/dataset
 .. _pip: https://pip.pypa.io/
 .. _PyPI: https://pypi.org/project/bioscan-dataset/
-.. _readthedocs: https://bioscan-dataset.readthedocs.io/en/v1.3.0/
+.. _readthedocs: https://bioscan-dataset.readthedocs.io
 .. _what-is-DNA-barcoding: https://www.ibol.org/phase1/about-us/what-is-dna-barcoding/
 .. _what-is-DNA-BIN: https://portal.boldsystems.org/bin

--- a/bioscan_dataset/__meta__.py
+++ b/bioscan_dataset/__meta__.py
@@ -1,6 +1,6 @@
 name = "bioscan-dataset"
 path = name.lower().replace("-", "_").replace(" ", "_")
-version = "1.3.0"
+version = "1.3.dev0"
 author = "Scott C. Lowe"
 author_email = "scott.code.lowe@gmail.com"
 description = "PyTorch torchvision-style datasets for BIOSCAN-1M and BIOSCAN-5M."

--- a/bioscan_dataset/__meta__.py
+++ b/bioscan_dataset/__meta__.py
@@ -1,6 +1,6 @@
 name = "bioscan-dataset"
 path = name.lower().replace("-", "_").replace(" ", "_")
-version = "1.2.dev1"
+version = "1.3.0"
 author = "Scott C. Lowe"
 author_email = "scott.code.lowe@gmail.com"
 description = "PyTorch torchvision-style datasets for BIOSCAN-1M and BIOSCAN-5M."


### PR DESCRIPTION
Add v1.3.0 to the changelog, and update the version number when installing from github to v1.3.dev0 to indicate it is unstable.

The release has already been pushed to [PyPI](https://pypi.org/project/bioscan-dataset/1.3.0/), [GitHub](https://github.com/bioscan-ml/dataset/releases/tag/v1.3.0), and [readthedocs](https://bioscan-dataset.readthedocs.io/en/v1.3.0/).